### PR TITLE
ci: add verify-checksums job to prevent brew formula drift

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -130,3 +130,54 @@ jobs:
           git diff --cached --quiet && exit 0
           git commit -m "Update claude-in-mobile to ${{ steps.version.outputs.version }}"
           git push
+
+  verify-checksums:
+    needs: update-homebrew
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Extract version from tag
+        id: version
+        run: echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+
+      - name: Download release assets and verify against formula
+        env:
+          GH_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          REPO="AlexGladkov/claude-in-mobile"
+          TAP_REPO="AlexGladkov/homebrew-claude-in-mobile"
+          FAILED=0
+
+          echo "::group::Fetching formula from tap"
+          gh api "repos/${TAP_REPO}/contents/Formula/claude-in-mobile.rb" --jq '.content' | base64 -d > formula.rb
+          cat formula.rb
+          echo "::endgroup::"
+
+          for ARCH in darwin-arm64 darwin-x86_64; do
+            ASSET="claude-in-mobile-${VERSION}-${ARCH}.tar.gz"
+            URL="https://github.com/${REPO}/releases/download/v${VERSION}/${ASSET}"
+
+            echo "::group::Verifying ${ARCH}"
+            echo "Downloading ${URL}"
+            curl -fsSL -o "${ASSET}" "${URL}"
+
+            ACTUAL=$(shasum -a 256 "${ASSET}" | awk '{print $1}')
+            echo "Actual SHA256: ${ACTUAL}"
+
+            if ! grep -q "${ACTUAL}" formula.rb; then
+              echo "::error::Checksum mismatch for ${ARCH}! Formula does not contain ${ACTUAL}"
+              FAILED=1
+            else
+              echo "Checksum verified for ${ARCH}"
+            fi
+            echo "::endgroup::"
+          done
+
+          if [ "$FAILED" -ne 0 ]; then
+            echo "::error::Checksum verification failed! Release assets do not match the Homebrew formula."
+            echo "::error::This usually means release assets were manually replaced after CI updated the formula."
+            exit 1
+          fi
+
+          echo "All checksums verified successfully"


### PR DESCRIPTION
## Summary

- Add `verify-checksums` CI job that runs after `update-homebrew` in the release workflow
- Downloads release assets from GitHub Releases and verifies their SHA256 hashes match the Homebrew formula in the tap repo
- Fails with a clear error if checksums don't match, catching cases where release assets are manually re-uploaded after CI

## Context

Issue #21 (and previously #4) — `brew install claude-in-mobile` fails because release assets were re-uploaded after CI had already written checksums to the Homebrew formula. This is now the **second time** this has happened.

**Immediate fix** (already merged): https://github.com/AlexGladkov/homebrew-claude-in-mobile/pull/5
**Prevention** (this PR): verify-checksums CI step catches this automatically on future releases.

Closes #21

## How it works

```
build → release → update-homebrew → verify-checksums
```

The new `verify-checksums` job:
1. Fetches the formula from the tap repo via GitHub API
2. Downloads each release asset from GitHub Releases (same URL users get)
3. Computes SHA256 and checks it exists in the formula
4. Fails the pipeline with `::error::` annotations if mismatch detected

## Test plan

- [ ] Verify workflow YAML is valid (`actionlint` or GitHub Actions syntax check)
- [ ] Next release (`v3.4.0+`) should show green `verify-checksums` job
- [ ] Manually replacing a release asset after CI should cause `verify-checksums` to fail

> This PR was generated with assistance from Claude Code (Claude Opus 4.6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)