### PR TITLE
feat: add device_viewport tool for screen size detection

### DIFF
--- a/src/adapters/android-adapter.ts
+++ b/src/adapters/android-adapter.ts
@@ -165,6 +165,12 @@ export class AndroidAdapter implements PlatformAdapter {
     return `Reset permissions for ${packageName}`;
   }
 
+  // ============ Viewport ============
+
+  async getViewportSize(): Promise<{ width: number; height: number }> {
+    return this.client.getScreenSize();
+  }
+
   // ============ System ============
 
   shell(command: string): string {

--- a/src/adapters/aurora-adapter.ts
+++ b/src/adapters/aurora-adapter.ts
@@ -144,6 +144,25 @@ export class AuroraAdapter implements PlatformAdapter {
     throw new Error("Permission management is not supported for Aurora platform");
   }
 
+  // ============ Viewport ============
+
+  async getViewportSize(): Promise<{ width: number; height: number }> {
+    try {
+      const output = this.client.shell("wm size");
+      const match = output.match(/(\d+)x(\d+)/);
+      if (match) {
+        return { width: parseInt(match[1]), height: parseInt(match[2]) };
+      }
+    } catch {
+      // ignore — fallback to screenshot dimensions
+    }
+    // Fallback: get size from screenshot
+    const { Jimp } = await import("jimp");
+    const buffer = this.client.screenshotRaw();
+    const image = await Jimp.read(buffer);
+    return { width: image.width, height: image.height };
+  }
+
   // ============ System ============
 
   shell(command: string): string {

--- a/src/adapters/browser-adapter.ts
+++ b/src/adapters/browser-adapter.ts
@@ -152,6 +152,17 @@ export class BrowserAdapter implements PlatformAdapter {
     throw new Error("resetPermissions is not supported for browser platform.");
   }
 
+  // -- Viewport --
+  async getViewportSize(): Promise<{ width: number; height: number }> {
+    const session = this.getActiveSession();
+    const { result } = await session.cdp.Runtime.evaluate({
+      expression: `JSON.stringify({width: window.innerWidth, height: window.innerHeight})`,
+      returnByValue: true,
+    });
+    const parsed = JSON.parse(result.value as string);
+    return { width: parsed.width, height: parsed.height };
+  }
+
   // -- System (stub) --
   shell(_cmd: string): string {
     throw new Error("shell is not supported for browser platform.");

--- a/src/adapters/desktop-adapter.ts
+++ b/src/adapters/desktop-adapter.ts
@@ -191,6 +191,13 @@ export class DesktopAdapter implements PlatformAdapter {
     throw new Error("Permission management is not supported for desktop platform");
   }
 
+  // ============ Viewport ============
+
+  async getViewportSize(): Promise<{ width: number; height: number }> {
+    this.ensureRunning();
+    return this.client.getScreenSize();
+  }
+
   // ============ System ============
 
   shell(command: string): string {

--- a/src/adapters/ios-adapter.ts
+++ b/src/adapters/ios-adapter.ts
@@ -152,6 +152,12 @@ export class IosAdapter implements PlatformAdapter {
     return `Reset permissions for ${bundleId}`;
   }
 
+  // ============ Viewport ============
+
+  async getViewportSize(): Promise<{ width: number; height: number }> {
+    return this.client.getViewportSize();
+  }
+
   // ============ System ============
 
   shell(command: string): string {

--- a/src/adapters/platform-adapter.ts
+++ b/src/adapters/platform-adapter.ts
@@ -80,6 +80,11 @@ export interface PlatformAdapter {
   revokePermission(packageOrBundleId: string, permission: string): string;
   resetPermissions(packageOrBundleId: string): string;
 
+  // ============ Viewport ============
+
+  /** Get the viewport/screen size of the active device in device pixels. */
+  getViewportSize(): Promise<{ width: number; height: number }>;
+
   // ============ System ============
 
   shell(command: string): string;

--- a/src/device-manager.ts
+++ b/src/device-manager.ts
@@ -371,6 +371,13 @@ export class DeviceManager {
     return adapter.shell(command);
   }
 
+  // ============ Viewport ============
+
+  async getViewportSize(platform?: Platform): Promise<{ width: number; height: number }> {
+    const adapter = this.getAdapter(platform);
+    return adapter.getViewportSize();
+  }
+
   // ============ Raw client accessors (used by tools directly) ============
 
   getAndroidClient(): AdbClient {

--- a/src/index.ts
+++ b/src/index.ts
@@ -126,6 +126,12 @@ registerAliases({
   // file (aurora)
   "push_file": "file_push",
   "pull_file": "file_pull",
+  // viewport
+  "get_viewport_size": "device_viewport",
+  "screen_size": "device_viewport",
+  "viewport_size": "device_viewport",
+  "get_viewport": "device_viewport",
+  "get_resolution": "device_viewport",
   // LLM misnaming helpers
   "press_button": "input_key",
   "type_text": "input_text",

--- a/src/ios/client.ts
+++ b/src/ios/client.ts
@@ -405,6 +405,22 @@ export class IosClient {
   }
 
   /**
+   * Get viewport size from WDA, with fallback to screenshot dimensions.
+   */
+  async getViewportSize(): Promise<{ width: number; height: number }> {
+    try {
+      const wdaClient = await this.ensureWDA();
+      return await wdaClient.getWindowSize();
+    } catch {
+      // Fallback: get size from screenshot
+      const { Jimp } = await import("jimp");
+      const buffer = this.screenshotRaw();
+      const image = await Jimp.read(buffer);
+      return { width: image.width, height: image.height };
+    }
+  }
+
+  /**
    * Open URL in simulator
    */
   openUrl(url: string): void {

--- a/src/tools/device-tools.ts
+++ b/src/tools/device-tools.ts
@@ -143,4 +143,40 @@ export const deviceTools: ToolDefinition[] = [
       return { text: `Current target: ${target} (${status})` };
     },
   },
+  {
+    tool: {
+      name: "device_viewport",
+      description:
+        "Get the viewport/screen size of the active device in device pixels. Also shows current screenshot scaling info. Useful for understanding coordinate space and layout dimensions.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          platform: {
+            type: "string",
+            enum: ["android", "ios", "desktop", "aurora", "browser"],
+            description: "Target platform. If not specified, uses the active target.",
+          },
+        },
+      },
+    },
+    handler: async (args, ctx) => {
+      const platform = args.platform as Platform | undefined;
+      const size = await ctx.deviceManager.getViewportSize(platform);
+
+      let result = `Viewport: ${size.width}x${size.height} (device pixels)`;
+
+      const currentPlatform = platform ?? ctx.deviceManager.getCurrentPlatform();
+      const scale = ctx.screenshotScaleMap.get(currentPlatform);
+      if (scale && (scale.scaleX !== 1 || scale.scaleY !== 1)) {
+        const imgW = Math.round(size.width / scale.scaleX);
+        const imgH = Math.round(size.height / scale.scaleY);
+        result += `\nScreenshot scale: ${scale.scaleX.toFixed(2)}x ${scale.scaleY.toFixed(2)}x (image coords are auto-scaled on tap)`;
+        result += `\nScreenshot image: ${imgW}x${imgH} -> device: ${size.width}x${size.height}`;
+      } else {
+        result += `\nScreenshot scale: 1:1 (no scaling active)`;
+      }
+
+      return { text: result };
+    },
+  },
 ];


### PR DESCRIPTION
## Summary

- Add new MCP tool `device_viewport` that returns actual device screen/viewport size in device pixels
- Includes current screenshot scaling info (scale factors, image→device mapping)
- Implemented for all 5 platforms: Android, iOS, Desktop, Browser, Aurora
- Registered 5 LLM-friendly aliases: `get_viewport_size`, `screen_size`, `viewport_size`, `get_viewport`, `get_resolution`

Closes #19

## Implementation

| Platform | Method | Fallback |
|----------|--------|----------|
| Android | `adb shell wm size` | 1080x1920 default |
| iOS | WDA `getWindowSize()` | Screenshot dimensions via Jimp |
| Desktop | Focused window size via companion app | 1920x1080 default |
| Browser | CDP `window.innerWidth/innerHeight` | — |
| Aurora | `wm size` via shell | Screenshot dimensions via Jimp |

### Changes (10 files, +119 lines)

- `platform-adapter.ts` — added `getViewportSize()` to interface
- `android-adapter.ts` — delegates to `AdbClient.getScreenSize()`
- `ios-adapter.ts` + `ios/client.ts` — WDA with screenshot fallback
- `desktop-adapter.ts` — delegates to `DesktopClient.getScreenSize()`
- `browser-adapter.ts` — CDP Runtime.evaluate
- `aurora-adapter.ts` — `wm size` + screenshot fallback
- `device-manager.ts` — proxy method
- `device-tools.ts` — MCP tool definition
- `index.ts` — alias registration

### Example response

```
Viewport: 1080x2400 (device pixels)
Screenshot scale: 2.00x 2.50x (image coords are auto-scaled on tap)
Screenshot image: 540x960 -> device: 1080x2400
```

## Test plan

- [ ] `npm run build` passes (verified locally)
- [ ] Android: `device_viewport` returns correct dimensions from connected device
- [ ] iOS: returns WDA window size or falls back to screenshot
- [ ] Browser: returns innerWidth/innerHeight of active tab
- [ ] Desktop: returns focused window dimensions
- [ ] Aliases resolve correctly (`screen_size`, `get_viewport_size`, etc.)

> This PR was generated with assistance from Claude Code (Claude Opus 4.6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)