### PR TITLE
feat(adb): discover adb binary outside PATH; surface ADB_NOT_INSTALLED clearly

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,8 +184,20 @@ claude mcp add --transport stdio mobile -- cmd /c npx claude-in-mobile@latest
 ## Requirements
 
 ### Android
-- ADB installed and in PATH
+- ADB installed (PATH or auto-discovered SDK location — see below)
 - Connected Android device (USB debugging enabled) or emulator
+
+**ADB binary discovery** — tried in this order:
+1. `ADB_PATH` env var (explicit override, e.g. `ADB_PATH=/path/to/adb`)
+2. `ANDROID_HOME/platform-tools/adb[.exe]`
+3. `ANDROID_SDK_ROOT/platform-tools/adb[.exe]`
+4. Android Studio default install location:
+   - **Windows:** `%LOCALAPPDATA%\Android\Sdk\platform-tools\adb.exe`
+   - **macOS:** `~/Library/Android/sdk/platform-tools/adb`
+   - **Linux:** `~/Android/Sdk/platform-tools/adb`
+5. `adb` from `PATH` (works out of the box for `brew install android-platform-tools`)
+
+If none of these resolve, `device(action:'list')` throws `[ADB_NOT_INSTALLED]` listing the paths it tried — set `ADB_PATH` to point at your binary.
 
 ### iOS
 - macOS with Xcode installed

--- a/src/adapters/android-adapter.ts
+++ b/src/adapters/android-adapter.ts
@@ -18,6 +18,7 @@ import type {
 } from "./platform-adapter.js";
 import type { Device } from "../device-manager.js";
 import { AdbClient } from "../adb/client.js";
+import { MobileError } from "../errors.js";
 import { compressScreenshot, type CompressOptions } from "../utils/image.js";
 
 export class AndroidAdapter
@@ -49,7 +50,12 @@ export class AndroidAdapter
         state: d.state,
         isSimulator: d.id.startsWith("emulator"),
       }));
-    } catch {
+    } catch (e) {
+      // Propagate when the cause is structural (adb not installed) — silently swallowing
+      // sends users hunting for cable/auth problems when the real fix is `ADB_PATH=...`.
+      // Transient failures (offline daemon, permission denied) still return [] so callers
+      // can degrade gracefully.
+      if (e instanceof MobileError && e.code === "ADB_NOT_INSTALLED") throw e;
       return [];
     }
   }

--- a/src/adb/client.ts
+++ b/src/adb/client.ts
@@ -1,6 +1,7 @@
 import { execSync, exec, execFile } from "child_process";
 import { promisify } from "util";
 import { classifyAdbError } from "../errors.js";
+import { resolveAdbPath, quoteAdbPath } from "./resolver.js";
 import { validatePackageName, validatePermission, validateDeviceId, validateLogTag, validateLogTimestamp } from "../utils/sanitize.js";
 
 const execAsyncCmd = promisify(exec);
@@ -8,6 +9,11 @@ const execFileAsync = promisify(execFile);
 
 const EXEC_TIMEOUT_MS = 15_000;      // 15s for text commands
 const EXEC_RAW_TIMEOUT_MS = 30_000;  // 30s for binary (screenshots)
+
+/** Resolved adb binary path, quoted for safe shell inclusion. Throws if adb not found. */
+function adbCmd(): string {
+  return quoteAdbPath(resolveAdbPath());
+}
 
 export interface Device {
   id: string;
@@ -33,7 +39,7 @@ export class AdbClient {
    * Execute ADB command and return stdout as string
    */
   exec(command: string): string {
-    const fullCommand = `adb ${this.deviceFlag} ${command}`;
+    const fullCommand = `${adbCmd()} ${this.deviceFlag} ${command}`;
     try {
       return execSync(fullCommand, {
         encoding: "utf-8",
@@ -53,7 +59,7 @@ export class AdbClient {
    * Execute ADB command and return raw bytes (for screenshots)
    */
   execRaw(command: string): Buffer {
-    const fullCommand = `adb ${this.deviceFlag} ${command}`;
+    const fullCommand = `${adbCmd()} ${this.deviceFlag} ${command}`;
     try {
       return execSync(fullCommand, {
         timeout: EXEC_RAW_TIMEOUT_MS,
@@ -72,7 +78,7 @@ export class AdbClient {
    * Execute ADB command async (non-blocking)
    */
   async execAsync(command: string): Promise<string> {
-    const fullCommand = `adb ${this.deviceFlag} ${command}`;
+    const fullCommand = `${adbCmd()} ${this.deviceFlag} ${command}`;
     try {
       const { stdout } = await execAsyncCmd(fullCommand, {
         timeout: EXEC_TIMEOUT_MS,
@@ -95,9 +101,10 @@ export class AdbClient {
     const args = this.deviceId
       ? ["-s", this.deviceId, ...command.split(/\s+/)]
       : command.split(/\s+/);
-    const fullCommand = `adb ${args.join(" ")}`;
+    const adbBin = resolveAdbPath();
+    const fullCommand = `${quoteAdbPath(adbBin)} ${args.join(" ")}`;
     try {
-      const { stdout } = await execFileAsync("adb", args, {
+      const { stdout } = await execFileAsync(adbBin, args, {
         timeout: EXEC_RAW_TIMEOUT_MS,
         maxBuffer: 50 * 1024 * 1024,
         encoding: "buffer" as BufferEncoding,
@@ -116,7 +123,7 @@ export class AdbClient {
    * Get list of connected devices
    */
   getDevices(): Device[] {
-    const output = execSync("adb devices -l", { encoding: "utf-8", timeout: EXEC_TIMEOUT_MS });
+    const output = execSync(`${adbCmd()} devices -l`, { encoding: "utf-8", timeout: EXEC_TIMEOUT_MS });
     const lines = output.split("\n").slice(1); // Skip header
 
     return lines

--- a/src/adb/resolver.test.ts
+++ b/src/adb/resolver.test.ts
@@ -85,6 +85,26 @@ describe("resolveAdbPath", () => {
     expect(resolveAdbPath()).toBe("adb");
   });
 
+  if (isWin) {
+    it("detects Visual Studio bundled SDK at Program Files (x86)", () => {
+      const programFilesX86 = process.env["ProgramFiles(x86)"] ?? "C:\\Program Files (x86)";
+      const expected = join(programFilesX86, "Android", "android-sdk", "platform-tools", adbBin);
+      mockExists.mockImplementation((p) => p === expected);
+
+      expect(resolveAdbPath()).toBe(expected);
+    });
+
+    it("prefers ANDROID_HOME over Visual Studio default location", () => {
+      process.env.ANDROID_HOME = "C:\\custom-sdk";
+      const customAdb = join("C:\\custom-sdk", "platform-tools", adbBin);
+      const programFilesX86 = process.env["ProgramFiles(x86)"] ?? "C:\\Program Files (x86)";
+      const vsAdb = join(programFilesX86, "Android", "android-sdk", "platform-tools", adbBin);
+      mockExists.mockImplementation((p) => p === customAdb || p === vsAdb);
+
+      expect(resolveAdbPath()).toBe(customAdb);
+    });
+  }
+
   it("throws AdbNotInstalledError listing all probed paths when nothing works", () => {
     mockExists.mockReturnValue(false);
     mockExec.mockImplementation(() => {

--- a/src/adb/resolver.test.ts
+++ b/src/adb/resolver.test.ts
@@ -1,0 +1,131 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { existsSync } from "fs";
+import { platform } from "os";
+import { join } from "path";
+
+vi.mock("fs", async () => {
+  const actual = await vi.importActual<typeof import("fs")>("fs");
+  return { ...actual, existsSync: vi.fn() };
+});
+
+vi.mock("child_process", async () => {
+  const actual = await vi.importActual<typeof import("child_process")>("child_process");
+  return { ...actual, execSync: vi.fn() };
+});
+
+import { resolveAdbPath, _resetCacheForTests, quoteAdbPath } from "./resolver.js";
+import { execSync } from "child_process";
+import { AdbNotInstalledError } from "../errors.js";
+
+const mockExists = existsSync as unknown as ReturnType<typeof vi.fn>;
+const mockExec = execSync as unknown as ReturnType<typeof vi.fn>;
+const isWin = platform() === "win32";
+const adbBin = isWin ? "adb.exe" : "adb";
+
+const ENV_KEYS = ["ADB_PATH", "ANDROID_HOME", "ANDROID_SDK_ROOT"] as const;
+const savedEnv: Record<string, string | undefined> = {};
+
+beforeEach(() => {
+  for (const k of ENV_KEYS) {
+    savedEnv[k] = process.env[k];
+    delete process.env[k];
+  }
+  mockExists.mockReset().mockReturnValue(false);
+  mockExec.mockReset().mockImplementation(() => {
+    throw new Error("not found");
+  });
+  _resetCacheForTests();
+});
+
+afterEach(() => {
+  for (const k of ENV_KEYS) {
+    if (savedEnv[k] === undefined) delete process.env[k];
+    else process.env[k] = savedEnv[k];
+  }
+});
+
+describe("resolveAdbPath", () => {
+  it("returns ADB_PATH when set and file exists", () => {
+    process.env.ADB_PATH = "/custom/adb";
+    mockExists.mockImplementation((p) => p === "/custom/adb");
+
+    expect(resolveAdbPath()).toBe("/custom/adb");
+  });
+
+  it("prefers ADB_PATH over ANDROID_HOME when both exist", () => {
+    process.env.ADB_PATH = "/custom/adb";
+    process.env.ANDROID_HOME = "/sdk-home";
+    mockExists.mockReturnValue(true); // both exist
+
+    expect(resolveAdbPath()).toBe("/custom/adb");
+  });
+
+  it("falls back to ANDROID_HOME when ADB_PATH not set", () => {
+    const root = isWin ? "C:\\sdk-home" : "/sdk-home";
+    process.env.ANDROID_HOME = root;
+    const expected = join(root, "platform-tools", adbBin);
+    mockExists.mockImplementation((p) => p === expected);
+
+    expect(resolveAdbPath()).toBe(expected);
+  });
+
+  it("falls back to ANDROID_SDK_ROOT after ANDROID_HOME", () => {
+    const root = isWin ? "C:\\sdk-root" : "/sdk-root";
+    process.env.ANDROID_SDK_ROOT = root;
+    const expected = join(root, "platform-tools", adbBin);
+    mockExists.mockImplementation((p) => p === expected);
+
+    expect(resolveAdbPath()).toBe(expected);
+  });
+
+  it("falls back to PATH when no candidate file exists", () => {
+    mockExists.mockReturnValue(false);
+    mockExec.mockReturnValue(Buffer.from("found"));
+
+    expect(resolveAdbPath()).toBe("adb");
+  });
+
+  it("throws AdbNotInstalledError listing all probed paths when nothing works", () => {
+    mockExists.mockReturnValue(false);
+    mockExec.mockImplementation(() => {
+      throw new Error("not found");
+    });
+
+    let captured: AdbNotInstalledError | null = null;
+    try {
+      resolveAdbPath();
+    } catch (e) {
+      captured = e as AdbNotInstalledError;
+    }
+
+    expect(captured).toBeInstanceOf(AdbNotInstalledError);
+    expect(captured?.code).toBe("ADB_NOT_INSTALLED");
+    expect(captured?.message).toContain("Probed locations:");
+    expect(captured?.message).toContain("PATH: adb");
+  });
+
+  it("memoizes the resolved path across calls", () => {
+    process.env.ADB_PATH = "/custom/adb";
+    mockExists.mockImplementation((p) => p === "/custom/adb");
+
+    const first = resolveAdbPath();
+    mockExists.mockReturnValue(false); // would fail second time if not cached
+
+    expect(resolveAdbPath()).toBe(first);
+  });
+});
+
+describe("quoteAdbPath", () => {
+  it("does not quote bare 'adb'", () => {
+    expect(quoteAdbPath("adb")).toBe("adb");
+    expect(quoteAdbPath("adb.exe")).toBe("adb.exe");
+  });
+
+  it("quotes paths with spaces", () => {
+    expect(quoteAdbPath("/Program Files/adb.exe")).toBe('"/Program Files/adb.exe"');
+  });
+
+  it("does not double-quote already-quoted paths", () => {
+    expect(quoteAdbPath('"/already/quoted"')).toBe('"/already/quoted"');
+  });
+});

--- a/src/adb/resolver.ts
+++ b/src/adb/resolver.ts
@@ -1,0 +1,127 @@
+/**
+ * Resolves the path to the `adb` binary.
+ *
+ * Priority:
+ *   1. ADB_PATH env var (explicit override)
+ *   2. ANDROID_HOME / ANDROID_SDK_ROOT env vars + /platform-tools/adb[.exe]
+ *   3. Platform-default SDK locations (Android Studio defaults)
+ *   4. `adb` from PATH (fallback — works when adb is on PATH, e.g. macOS Homebrew)
+ *
+ * Result is memoized: the first call probes the filesystem, subsequent calls
+ * return the cached path. Tests call `_resetCacheForTests()` to clear it.
+ *
+ * Throws AdbNotInstalledError with the list of probed paths when nothing works.
+ */
+
+import { existsSync } from "fs";
+import { homedir, platform } from "os";
+import { join } from "path";
+import { execSync } from "child_process";
+import { AdbNotInstalledError } from "../errors.js";
+
+let cachedPath: string | null = null;
+let resolved = false;
+
+const isWin = platform() === "win32";
+const adbBinary = isWin ? "adb.exe" : "adb";
+
+/** Build candidate paths in priority order; first existing wins. */
+function buildCandidates(): { path: string; source: string }[] {
+  const candidates: { path: string; source: string }[] = [];
+
+  // 1. Explicit override
+  if (process.env.ADB_PATH) {
+    candidates.push({ path: process.env.ADB_PATH, source: "ADB_PATH" });
+  }
+
+  // 2. Android SDK env vars (ANDROID_HOME first; ANDROID_SDK_ROOT is the newer name but both are common)
+  for (const envVar of ["ANDROID_HOME", "ANDROID_SDK_ROOT"]) {
+    const root = process.env[envVar];
+    if (root) {
+      candidates.push({
+        path: join(root, "platform-tools", adbBinary),
+        source: `${envVar}/platform-tools`,
+      });
+    }
+  }
+
+  // 3. Platform defaults — where Android Studio installs the SDK by default
+  const home = homedir();
+  if (isWin) {
+    // %LOCALAPPDATA%\Android\Sdk\platform-tools\adb.exe
+    const localAppData = process.env.LOCALAPPDATA ?? join(home, "AppData", "Local");
+    candidates.push({
+      path: join(localAppData, "Android", "Sdk", "platform-tools", adbBinary),
+      source: "LOCALAPPDATA/Android/Sdk",
+    });
+  } else if (platform() === "darwin") {
+    candidates.push({
+      path: join(home, "Library", "Android", "sdk", "platform-tools", adbBinary),
+      source: "~/Library/Android/sdk",
+    });
+  } else {
+    // linux + others: ~/Android/Sdk is Android Studio default on Linux
+    candidates.push({
+      path: join(home, "Android", "Sdk", "platform-tools", adbBinary),
+      source: "~/Android/Sdk",
+    });
+  }
+
+  return candidates;
+}
+
+/** Check if `adb` is on PATH by asking the shell to locate it. */
+function adbOnPath(): boolean {
+  try {
+    // `where` on Windows, `command -v` on Unix — both exit 0 only on success.
+    const cmd = isWin ? "where adb" : "command -v adb";
+    execSync(cmd, { stdio: "pipe", timeout: 3000 });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Resolve the adb binary path. Memoized after first successful call.
+ * Throws AdbNotInstalledError listing all probed paths when nothing is found.
+ */
+export function resolveAdbPath(): string {
+  if (resolved && cachedPath !== null) return cachedPath;
+
+  const candidates = buildCandidates();
+  const tried: string[] = [];
+
+  for (const { path, source } of candidates) {
+    tried.push(`  - ${source}: ${path}`);
+    if (existsSync(path)) {
+      cachedPath = path;
+      resolved = true;
+      return path;
+    }
+  }
+
+  // Last resort: bare `adb` on PATH
+  tried.push("  - PATH: adb");
+  if (adbOnPath()) {
+    cachedPath = "adb";
+    resolved = true;
+    return "adb";
+  }
+
+  throw new AdbNotInstalledError(tried);
+}
+
+/** Quote a path for safe inclusion in a shell command (handles spaces in Windows paths). */
+export function quoteAdbPath(path: string): string {
+  // Bare `adb` doesn't need quoting; full paths might contain spaces (e.g. "Program Files").
+  if (path === "adb" || path === "adb.exe") return path;
+  if (path.startsWith('"') && path.endsWith('"')) return path;
+  return `"${path}"`;
+}
+
+/** @internal — for tests only */
+export function _resetCacheForTests(): void {
+  cachedPath = null;
+  resolved = false;
+}

--- a/src/adb/resolver.ts
+++ b/src/adb/resolver.ts
@@ -48,11 +48,23 @@ function buildCandidates(): { path: string; source: string }[] {
   // 3. Platform defaults — where Android Studio installs the SDK by default
   const home = homedir();
   if (isWin) {
-    // %LOCALAPPDATA%\Android\Sdk\platform-tools\adb.exe
+    // %LOCALAPPDATA%\Android\Sdk\platform-tools\adb.exe — Android Studio default (per-user)
     const localAppData = process.env.LOCALAPPDATA ?? join(home, "AppData", "Local");
     candidates.push({
       path: join(localAppData, "Android", "Sdk", "platform-tools", adbBinary),
       source: "LOCALAPPDATA/Android/Sdk",
+    });
+    // Visual Studio's bundled Android SDK (Xamarin/MAUI workload installs here, system-wide).
+    // Different folder naming from Android Studio: "android-sdk" (lowercase + hyphen) vs "Sdk".
+    const programFilesX86 = process.env["ProgramFiles(x86)"] ?? "C:\\Program Files (x86)";
+    candidates.push({
+      path: join(programFilesX86, "Android", "android-sdk", "platform-tools", adbBinary),
+      source: "Program Files (x86)/Android/android-sdk (Visual Studio)",
+    });
+    const programFiles = process.env.ProgramFiles ?? "C:\\Program Files";
+    candidates.push({
+      path: join(programFiles, "Android", "android-sdk", "platform-tools", adbBinary),
+      source: "Program Files/Android/android-sdk",
     });
   } else if (platform() === "darwin") {
     candidates.push({

--- a/src/device-manager.ts
+++ b/src/device-manager.ts
@@ -223,12 +223,26 @@ export class DeviceManager {
 
   // ============ Device Management ============
 
-  getAllDevices(): Device[] {
+  /**
+   * Aggregate device list across adapters. Captures structural errors (e.g.
+   * ADB_NOT_INSTALLED) per-platform so callers can surface root cause instead of
+   * an empty list. Returns devices found and a parallel `errors` array.
+   */
+  getAllDevicesWithErrors(): { devices: Device[]; errors: { platform: Platform; error: Error }[] } {
     const devices: Device[] = [];
-    for (const adapter of this.adapters.values()) {
-      devices.push(...adapter.listDevices());
+    const errors: { platform: Platform; error: Error }[] = [];
+    for (const [platform, adapter] of this.adapters.entries()) {
+      try {
+        devices.push(...adapter.listDevices());
+      } catch (e) {
+        errors.push({ platform, error: e instanceof Error ? e : new Error(String(e)) });
+      }
     }
-    return devices;
+    return { devices, errors };
+  }
+
+  getAllDevices(): Device[] {
+    return this.getAllDevicesWithErrors().devices;
   }
 
   getDevices(platform?: Platform): Device[] {
@@ -255,7 +269,7 @@ export class DeviceManager {
       };
     }
 
-    const devices = this.getAllDevices();
+    const { devices, errors } = this.getAllDevicesWithErrors();
 
     // Find device by ID
     let device = devices.find((d) => d.id === deviceId);
@@ -270,6 +284,12 @@ export class DeviceManager {
     }
 
     if (!device) {
+      // If a target platform's adapter failed structurally (e.g. ADB_NOT_INSTALLED), surface
+      // that — `Device not found` is misleading when the real cause is the toolchain itself.
+      const relevant = platform
+        ? errors.find((e) => e.platform === platform)
+        : errors[0];
+      if (relevant) throw relevant.error;
       throw new Error(`Device not found: ${deviceId}`);
     }
 

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -22,11 +22,14 @@ export class DeviceNotFoundError extends MobileError {
 }
 
 export class AdbNotInstalledError extends MobileError {
-  constructor() {
-    super(
-      "ADB is not installed or not in PATH.\n\nInstall Android SDK or run: brew install android-platform-tools",
-      "ADB_NOT_INSTALLED"
-    );
+  constructor(triedPaths?: string[]) {
+    const base = "ADB is not installed or not found.";
+    const install = "Install Android SDK or run: brew install android-platform-tools (macOS) / install Android Studio (Windows/Linux)";
+    const hint = "Or set ADB_PATH=/path/to/adb to point at a specific binary.";
+    const probed = triedPaths && triedPaths.length > 0
+      ? `\n\nProbed locations:\n${triedPaths.join("\n")}`
+      : "";
+    super(`${base}\n\n${install}\n${hint}${probed}`, "ADB_NOT_INSTALLED");
   }
 }
 


### PR DESCRIPTION
## Problem

On Windows, Android Studio installs `adb.exe` under `%LOCALAPPDATA%\Android\Sdk\platform-tools\` and **does not add it to PATH**. The MCP server inherits a minimal env from its parent process, so:

- `device(action:'list')` returns `[]` even when `adb devices` (run from a terminal with the SDK path) clearly sees connected devices.
- `device(action:'set', deviceId:X)` then fails with `Device not found: X`, sending users hunting for cable / USB-debug-auth issues when the real cause is an unresolved adb binary.

Reproduced on Windows 11 + Samsung phone connected via Visual Studio's bundled SDK at `C:\Users\<user>\AppData\Local\Android\Sdk\platform-tools\adb.exe`.

## Changes

- **`src/adb/resolver.ts`** *(new)* — probe `ADB_PATH` → `ANDROID_HOME` → `ANDROID_SDK_ROOT` → OS-default Android Studio install location → fall back to `adb` from PATH. Memoized; throws `AdbNotInstalledError` listing the paths it tried.
- **`src/adb/client.ts`** — route every `adb` invocation (5 sites) through the resolver. `quoteAdbPath` handles paths with spaces (e.g. `Program Files`).
- **`src/adapters/android-adapter.ts`** — stop swallowing `ADB_NOT_INSTALLED` in `listDevices()` so callers see the real cause; transient errors still return `[]` for graceful degradation.
- **`src/device-manager.ts`** — `getAllDevicesWithErrors()` captures per-platform failures; `setDevice()` rethrows the underlying error instead of the misleading `Device not found`.
- **`src/errors.ts`** — `AdbNotInstalledError` accepts the list of probed paths and recommends `ADB_PATH=`.
- **`src/adb/resolver.test.ts`** *(new, +10 tests)* — priority order, memoization, PATH fallback, missing-everywhere error path.
- **`README.md`** — document discovery order under Android requirements.

## Verification

- `npm test` — **701 passing** (was 691; +10 new resolver tests).
- `npm run build` — clean.
- End-to-end on Windows: without setting any env var, `node -e "import('./dist/adb/client.js').then(({AdbClient}) => console.log(new AdbClient().getDevices()))"` returns the connected Samsung phone. Same flow exercises `screenshotRaw()`, `tap()`, and `exec('shell uiautomator dump …')` successfully.

## Backwards compatibility

- macOS users with `adb` in PATH (e.g. `brew install android-platform-tools`) hit the PATH fallback unchanged.
- Behavior in CI / tested-with-`adb`-on-PATH environments is unchanged because the new resolver simply degrades to `"adb"` when no other candidate resolves.
- No public API surface changed.