### PR TITLE
feat(android): add system_pid_of and system_is_running

### DIFF
--- a/src/tools/system-tools.test.ts
+++ b/src/tools/system-tools.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect, vi } from "vitest";
+import { systemTools } from "./system-tools.js";
+import { MobileError } from "../errors.js";
+import type { ToolContext } from "./context.js";
+
+function findHandler(name: string) {
+  const def = systemTools.find(t => t.tool.name === name);
+  if (!def) throw new Error(`Tool "${name}" not found in systemTools`);
+  return def.handler;
+}
+
+function makeMockContext(overrides?: Partial<ToolContext>): ToolContext {
+  return {
+    deviceManager: {
+      getCurrentPlatform: vi.fn(() => "android"),
+      getLogs: vi.fn(() => ""),
+      clearLogs: vi.fn(() => "Logcat buffer cleared"),
+      shell: vi.fn(() => ""),
+    } as any,
+    getCachedElements: vi.fn(() => []),
+    setCachedElements: vi.fn(),
+    lastScreenshotMap: new Map(),
+    lastUiTreeMap: new Map(),
+    screenshotScaleMap: new Map(),
+    generateActionHints: vi.fn(async () => ""),
+    getElementsForPlatform: vi.fn(async () => []),
+    iosTreeToUiElements: vi.fn(() => []),
+    formatIOSUITree: vi.fn(() => ""),
+    platformParam: { type: "string", enum: ["android", "ios", "desktop", "aurora", "browser"], description: "" },
+    handleTool: vi.fn(async () => ({ text: "ok" })),
+    ...overrides,
+  };
+}
+
+// ──────────────────────────────────────────────
+// system_pid_of — package name validation + parsing
+// ──────────────────────────────────────────────
+
+describe("system_pid_of", () => {
+  const handler = findHandler("system_pid_of");
+
+  it("rejects non-android platform", async () => {
+    const ctx = makeMockContext({
+      deviceManager: { getCurrentPlatform: vi.fn(() => "ios"), shell: vi.fn(() => "") } as any,
+    });
+    const result = await handler({ package: "com.example.app" }, ctx);
+    expect((result as { text: string }).text).toContain("only available for Android");
+  });
+
+  it("rejects package name with shell injection", async () => {
+    const ctx = makeMockContext();
+    await expect(handler({ package: "com.example;rm -rf /" }, ctx)).rejects.toThrow(MobileError);
+  });
+
+  it("returns parsed PID when pidof outputs a number", async () => {
+    const shell = vi.fn(() => "12345\n");
+    const ctx = makeMockContext({
+      deviceManager: { getCurrentPlatform: vi.fn(() => "android"), shell } as any,
+    });
+    const result = await handler({ package: "com.example.app" }, ctx);
+    expect((result as { text: string }).text).toBe("12345");
+    expect(shell).toHaveBeenCalledWith("pidof -s com.example.app", undefined);
+  });
+
+  it("returns 0 (not running) when pidof outputs empty", async () => {
+    const ctx = makeMockContext({
+      deviceManager: { getCurrentPlatform: vi.fn(() => "android"), shell: vi.fn(() => "") } as any,
+    });
+    const result = await handler({ package: "com.example.app" }, ctx);
+    expect((result as { text: string }).text).toContain("0 (not running)");
+  });
+
+  it("returns 0 (not running) when pidof outputs garbage", async () => {
+    const ctx = makeMockContext({
+      deviceManager: { getCurrentPlatform: vi.fn(() => "android"), shell: vi.fn(() => "not-a-number") } as any,
+    });
+    const result = await handler({ package: "com.example.app" }, ctx);
+    expect((result as { text: string }).text).toContain("0 (not running)");
+  });
+});
+
+// ──────────────────────────────────────────────
+// system_is_running — boolean wrapper
+// ──────────────────────────────────────────────
+
+describe("system_is_running", () => {
+  const handler = findHandler("system_is_running");
+
+  it("rejects non-android platform", async () => {
+    const ctx = makeMockContext({
+      deviceManager: { getCurrentPlatform: vi.fn(() => "desktop"), shell: vi.fn(() => "") } as any,
+    });
+    const result = await handler({ package: "com.example.app" }, ctx);
+    expect((result as { text: string }).text).toContain("only available for Android");
+  });
+
+  it("rejects package name with shell injection", async () => {
+    const ctx = makeMockContext();
+    await expect(handler({ package: "com.example|cat" }, ctx)).rejects.toThrow(MobileError);
+  });
+
+  it("returns 'true (pid=N)' when app is running", async () => {
+    const ctx = makeMockContext({
+      deviceManager: { getCurrentPlatform: vi.fn(() => "android"), shell: vi.fn(() => "9999") } as any,
+    });
+    const result = await handler({ package: "com.example.app" }, ctx);
+    expect((result as { text: string }).text).toBe("true (pid=9999)");
+  });
+
+  it("returns 'false' when app is not running", async () => {
+    const ctx = makeMockContext({
+      deviceManager: { getCurrentPlatform: vi.fn(() => "android"), shell: vi.fn(() => "") } as any,
+    });
+    const result = await handler({ package: "com.example.app" }, ctx);
+    expect((result as { text: string }).text).toBe("false");
+  });
+
+  it("returns 'false' when pidof outputs 0", async () => {
+    const ctx = makeMockContext({
+      deviceManager: { getCurrentPlatform: vi.fn(() => "android"), shell: vi.fn(() => "0") } as any,
+    });
+    const result = await handler({ package: "com.example.app" }, ctx);
+    expect((result as { text: string }).text).toBe("false");
+  });
+});

--- a/src/tools/system-tools.ts
+++ b/src/tools/system-tools.ts
@@ -2,7 +2,7 @@ import type { ToolDefinition } from "./registry.js";
 import type { ToolContext } from "./context.js";
 import type { Platform } from "../device-manager.js";
 import { truncateOutput } from "../utils/truncate.js";
-import { validateShellCommand, validateUrl, sanitizeForShell } from "../utils/sanitize.js";
+import { validateShellCommand, validateUrl, sanitizeForShell, validatePackageName } from "../utils/sanitize.js";
 
 export const systemTools: ToolDefinition[] = [
   {
@@ -135,6 +135,64 @@ export const systemTools: ToolDefinition[] = [
       const platform = args.platform as Platform | undefined;
       const result = ctx.deviceManager.clearLogs(platform);
       return { text: result };
+    },
+  },
+  {
+    tool: {
+      name: "system_pid_of",
+      description: "Get the PID of a running app process by package name (Android only). Returns 0 when the package is not running. Useful for verifying app launch / crash detection without parsing the full ps output.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          package: { type: "string", description: "Package name, e.g., com.android.settings" },
+          platform: { type: "string", enum: ["android", "ios", "desktop", "aurora", "browser"], description: "Target platform. If not specified, uses the active target." },
+        },
+        required: ["package"],
+      },
+    },
+    handler: async (args, ctx) => {
+      const platform = args.platform as Platform | undefined;
+      const currentPlatform = platform ?? ctx.deviceManager.getCurrentPlatform();
+      if (currentPlatform !== "android") {
+        return { text: "system_pid_of is only available for Android." };
+      }
+      const pkg = args.package as string;
+      validatePackageName(pkg);
+      // pidof -s returns single PID (first match); empty output if not running.
+      // Package name is whitelist-validated, no shell injection vector.
+      const raw = ctx.deviceManager.shell(`pidof -s ${pkg}`, platform).trim();
+      const pid = raw === "" ? 0 : parseInt(raw, 10);
+      if (Number.isNaN(pid) || pid <= 0) {
+        return { text: `0 (not running)` };
+      }
+      return { text: `${pid}` };
+    },
+  },
+  {
+    tool: {
+      name: "system_is_running",
+      description: "Check whether an app process is currently running by package name (Android only). Returns 'true' or 'false'. Convenience wrapper around system_pid_of for quick assertions.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          package: { type: "string", description: "Package name, e.g., com.android.settings" },
+          platform: { type: "string", enum: ["android", "ios", "desktop", "aurora", "browser"], description: "Target platform. If not specified, uses the active target." },
+        },
+        required: ["package"],
+      },
+    },
+    handler: async (args, ctx) => {
+      const platform = args.platform as Platform | undefined;
+      const currentPlatform = platform ?? ctx.deviceManager.getCurrentPlatform();
+      if (currentPlatform !== "android") {
+        return { text: "system_is_running is only available for Android." };
+      }
+      const pkg = args.package as string;
+      validatePackageName(pkg);
+      const raw = ctx.deviceManager.shell(`pidof -s ${pkg}`, platform).trim();
+      const pid = raw === "" ? 0 : parseInt(raw, 10);
+      const running = !Number.isNaN(pid) && pid > 0;
+      return { text: running ? `true (pid=${pid})` : "false" };
     },
   },
   {


### PR DESCRIPTION
## Summary

Two tightly-scoped process visibility tools to avoid building blocked shell pipelines (`system_shell` rejects `$()`, `|`, `;` for safety) just to answer "is this app actually running?".

## Tools

- **`system_pid_of`** — Returns the PID of a running app process by package name, or 0 when not running. Uses `pidof -s <pkg>` under the hood. Package name is whitelist-validated via the existing `validatePackageName` helper (no shell-injection vector despite raw shell call).
- **`system_is_running`** — Convenience boolean wrapper. Returns `"true (pid=N)"` or `"false"`. Same package validation, same `pidof` under the hood.

## Use cases

- Verify `app_launch` actually started the process (poll until `pid > 0`)
- Detect crash (pid was N, now 0)
- Confirm `app_stop` took effect
- Pre-test check: skip flow if app already running

## Test plan

- [x] 5 tests for `system_pid_of` (platform guard, injection guard, numeric parse, empty output, garbage output)
- [x] 5 tests for `system_is_running` (platform guard, injection guard, running, not-running, pid=0 edge case)
- [x] Full suite: **749/749 tests pass across 25 test files**, no regressions