### PR TITLE
docs: clarify coordinate space for input_tap/double_tap/long_press/swipe

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,6 +288,17 @@ claude-in-mobile input android "hello world"
 claude-in-mobile ui-dump android | grep "Login"
 ```
 
+#### Coordinate space (raw `x`/`y` in tap / swipe / long_press)
+
+When you call an input tool with raw `x`/`y` (or `x1`/`y1`/`x2`/`y2` for swipe), the values are interpreted in **the most recent screenshot's pixel space** and auto-scaled to device coordinates before dispatch. The scale comes from the last `screen_capture` call: e.g., capture at `preset='low'` (270×480) on a 1080×2400 device sets a 4× factor, so `tap(135, 240)` becomes `tap(540, 960)` on the device.
+
+This is convenient for the common flow `screen_capture → reason about pixel → tap`, but has two gotchas worth knowing:
+
+- **Coordinates from `ui_find` / `ui_tree` are device coordinates**, not screenshot coordinates. They come from `uiautomator` which always reports in device space. If the most recent screenshot was at a low preset, passing those device coords as raw `x`/`y` will over-scale them. Prefer `index`, `text`, or `resourceId` for ui-sourced taps to avoid the issue entirely.
+- **No screenshot taken yet?** Then there's no scale stored, and raw `x`/`y` are passed through 1:1 as device coords.
+
+The cleanest mental model: *raw coords match whatever pixel space you're looking at on screen* (your last screenshot). For everything else, use the resolver fields (`index`, `text`, `resourceId`, `label`).
+
 ---
 
 ### iOS

--- a/src/tools/interaction-tools.ts
+++ b/src/tools/interaction-tools.ts
@@ -8,12 +8,20 @@ export const interactionTools: ToolDefinition[] = [
   {
     tool: {
       name: "input_tap",
-      description: "Tap by coordinates, text, resourceId, label, or element index",
+      description:
+        "Tap by coordinates, text, resourceId, label, or element index.\n\n" +
+        "COORDINATE SPACE: raw x/y are interpreted in the **last captured screenshot's pixel space** and " +
+        "auto-scaled to device coordinates before dispatch. If no screen(action:'capture') has been called yet, " +
+        "the scale defaults to 1× (i.e., x/y are treated as device coords). The resolution from the most recent " +
+        "screenshot is used — capturing at preset='low' (270×480) then tapping with x/y from that image works " +
+        "transparently. Coordinates returned by ui(action:'find') and ui(action:'tree') are ALREADY device " +
+        "coordinates from uiautomator; passing them as raw x/y when a low-res screenshot is the most recent " +
+        "capture will OVER-SCALE them. Prefer index/text/resourceId for ui_*-sourced taps to avoid this pitfall.",
       inputSchema: {
         type: "object",
         properties: {
-          x: { type: "number", description: "X coordinate to tap" },
-          y: { type: "number", description: "Y coordinate to tap" },
+          x: { type: "number", description: "X coordinate (screenshot pixel space — see tool description)" },
+          y: { type: "number", description: "Y coordinate (screenshot pixel space — see tool description)" },
           text: { type: "string", description: "Android: Element text. iOS: Element name (less reliable than label)" },
           label: { type: "string", description: "iOS only: Accessibility label (most reliable)" },
           resourceId: { type: "string", description: "Find element with this resource ID and tap it (Android only)" },
@@ -67,12 +75,12 @@ export const interactionTools: ToolDefinition[] = [
   {
     tool: {
       name: "input_double_tap",
-      description: "Double tap by coordinates, text, resourceId, or index",
+      description: "Double tap by coordinates, text, resourceId, or index. Raw x/y are screenshot-space and auto-scaled to device coordinates — see input_tap description for full coordinate space rules.",
       inputSchema: {
         type: "object",
         properties: {
-          x: { type: "number", description: "X coordinate to tap" },
-          y: { type: "number", description: "Y coordinate to tap" },
+          x: { type: "number", description: "X coordinate (screenshot pixel space)" },
+          y: { type: "number", description: "Y coordinate (screenshot pixel space)" },
           text: { type: "string", description: "Find element by text and double tap it (Android only)" },
           resourceId: { type: "string", description: "Find element with this resource ID and double tap it (Android only)" },
           index: { type: "number", description: "Double tap element by index from ui(action:'tree') output (Android only)" },
@@ -110,12 +118,12 @@ export const interactionTools: ToolDefinition[] = [
   {
     tool: {
       name: "input_long_press",
-      description: "Long press at coordinates or on element by text/label",
+      description: "Long press at coordinates or on element by text/label. Raw x/y are screenshot-space and auto-scaled to device coordinates — see input_tap description for full coordinate space rules.",
       inputSchema: {
         type: "object",
         properties: {
-          x: { type: "number", description: "X coordinate" },
-          y: { type: "number", description: "Y coordinate" },
+          x: { type: "number", description: "X coordinate (screenshot pixel space)" },
+          y: { type: "number", description: "Y coordinate (screenshot pixel space)" },
           label: { type: "string", description: "iOS only: Accessibility label (most reliable)" },
           text: { type: "string", description: "Find element by text (Android only)" },
           duration: { type: "number", description: "Duration in milliseconds (default: 1000)", default: 1000 },
@@ -165,15 +173,15 @@ export const interactionTools: ToolDefinition[] = [
   {
     tool: {
       name: "input_swipe",
-      description: "Swipe by direction or custom coordinates",
+      description: "Swipe by direction or custom coordinates. Raw x1/y1/x2/y2 are screenshot-space and auto-scaled to device coordinates — see input_tap description for full coordinate space rules.",
       inputSchema: {
         type: "object",
         properties: {
           direction: { type: "string", enum: ["up", "down", "left", "right"], description: "Swipe direction" },
-          x1: { type: "number", description: "Start X (for custom swipe)" },
-          y1: { type: "number", description: "Start Y (for custom swipe)" },
-          x2: { type: "number", description: "End X (for custom swipe)" },
-          y2: { type: "number", description: "End Y (for custom swipe)" },
+          x1: { type: "number", description: "Start X (screenshot pixel space)" },
+          y1: { type: "number", description: "Start Y (screenshot pixel space)" },
+          x2: { type: "number", description: "End X (screenshot pixel space)" },
+          y2: { type: "number", description: "End Y (screenshot pixel space)" },
           duration: { type: "number", description: "Duration in ms (default: 300)", default: 300 },
           hints: { type: "boolean", description: "Return hints about what changed after the action (new/gone elements, suggestions). Eliminates need for follow-up screen(action:'capture')/ui(action:'tree').", default: true },
           platform: { type: "string", enum: ["android", "ios", "desktop", "aurora", "browser"], description: "Target platform. If not specified, uses the active target." },


### PR DESCRIPTION
## Summary

Pure docs PR. Raw `x`/`y` arguments to input tools are interpreted in the most recent screenshot's pixel space and auto-scaled to device coordinates via `screenshotScaleMap` (set when `screen_capture` is called with `maxWidth`/`maxHeight` smaller than device resolution). The behavior is documented in code (`applyScale` helper) but **not** in tool descriptions or README, leading to surprises in real automation flows.

## Pitfalls this PR makes explicit

- `tap(415, 820)` producing `tap(2075, 4220)` because the last screenshot was at `preset='low'` on a 1080-wide device (5× scale).
- Confusion between coords reported by `ui_find` / `ui_tree` (which are device coords from uiautomator) vs raw `x`/`y` (screenshot coords) — passing the former as the latter when a low-res screenshot is the most recent capture causes silent over-scaling.

## Changes

- `input_tap` top-level description now spells out the coord-space rule, the "no screenshot taken yet" fallback (1× scale), and the `ui_*`-vs-raw pitfall. Recommends using `index`/`text`/`resourceId` for ui-sourced taps.
- `input_double_tap`, `input_long_press`, `input_swipe` descriptions add a one-line cross-reference to `input_tap` for full rules.
- Per-property descriptions for `x`/`y` (and `x1`/`y1`/`x2`/`y2` in swipe) now read `"(screenshot pixel space)"` instead of generic `"X coordinate"`.
- README Android section gets a "Coordinate space" subsection with the model + gotchas, anchored under the existing usage example.

No behavior change. **739/739 tests pass**, no regressions.