### PR TITLE
feat(android): app_restart tool + walk to clickable ancestor in find_tap

### DIFF
--- a/src/adb/ui-parser.test.ts
+++ b/src/adb/ui-parser.test.ts
@@ -5,6 +5,7 @@ import {
   findByResourceId,
   findByClassName,
   findClickable,
+  findClickableAncestor,
   findElements,
   findBestMatch,
   analyzeScreen,
@@ -337,6 +338,118 @@ describe("findBestMatch", () => {
     // The "Forgot password?" link is disabled
     const result = findBestMatch(elements, "Forgot password?");
     expect(result).toBeNull();
+  });
+});
+
+// ──────────────────────────────────────────────
+// findClickableAncestor
+// ──────────────────────────────────────────────
+
+describe("findClickableAncestor", () => {
+  // Pattern common in MAUI/Compose: visible TextView is non-clickable, but the
+  // parent ViewGroup at the same/larger bounds carries the gesture handler.
+  const textChild = makeTestElement({
+    text: "Products",
+    clickable: false,
+    bounds: { x1: 360, y1: 920, x2: 470, y2: 970 },
+  });
+  const clickableParent = makeTestElement({
+    className: "android.view.ViewGroup",
+    clickable: true,
+    bounds: { x1: 320, y1: 760, x2: 510, y2: 980 },
+  });
+  const screenRoot = makeTestElement({
+    className: "android.widget.FrameLayout",
+    clickable: true,
+    bounds: { x1: 0, y1: 0, x2: 1080, y2: 2400 },
+  });
+
+  it("returns null when target is itself clickable", () => {
+    const target = makeTestElement({ text: "OK", clickable: true });
+    const result = findClickableAncestor(target, [target, clickableParent]);
+    expect(result).toBeNull();
+  });
+
+  it("finds smallest clickable ancestor that contains target bounds", () => {
+    const result = findClickableAncestor(textChild, [textChild, clickableParent, screenRoot]);
+    expect(result).not.toBeNull();
+    expect(result).toBe(clickableParent);
+  });
+
+  it("ignores ancestor candidates that don't contain target bounds", () => {
+    const otherClickable = makeTestElement({
+      clickable: true,
+      bounds: { x1: 0, y1: 0, x2: 100, y2: 100 }, // far from target
+    });
+    const result = findClickableAncestor(textChild, [textChild, otherClickable]);
+    expect(result).toBeNull();
+  });
+
+  it("rejects screen-root containers via maxAreaMultiplier heuristic", () => {
+    // Only candidate is the full-screen container — far larger than target × 200
+    const result = findClickableAncestor(textChild, [textChild, screenRoot]);
+    expect(result).toBeNull();
+  });
+
+  it("accepts large containers when maxAreaMultiplier is loosened", () => {
+    const result = findClickableAncestor(textChild, [textChild, screenRoot], { maxAreaMultiplier: 100_000 });
+    expect(result).toBe(screenRoot);
+  });
+
+  it("returns null when no clickable ancestors at all", () => {
+    const result = findClickableAncestor(textChild, [textChild]);
+    expect(result).toBeNull();
+  });
+
+  it("ignores disabled clickable ancestors", () => {
+    const disabledParent = { ...clickableParent, enabled: false };
+    const result = findClickableAncestor(textChild, [textChild, disabledParent]);
+    expect(result).toBeNull();
+  });
+});
+
+// ──────────────────────────────────────────────
+// findBestMatch — walkToClickable behavior
+// ──────────────────────────────────────────────
+
+describe("findBestMatch walkToClickable", () => {
+  const textChild = makeTestElement({
+    text: "Products",
+    clickable: false,
+    bounds: { x1: 360, y1: 920, x2: 470, y2: 970 },
+  });
+  const clickableParent = makeTestElement({
+    className: "android.view.ViewGroup",
+    clickable: true,
+    bounds: { x1: 320, y1: 760, x2: 510, y2: 980 },
+  });
+
+  it("walks up to clickable ancestor by default when match is non-clickable", () => {
+    const result = findBestMatch([textChild, clickableParent], "Products");
+    expect(result).not.toBeNull();
+    expect(result!.element).toBe(clickableParent);
+    expect(result!.reason).toContain("via clickable ancestor");
+  });
+
+  it("returns matched element when walkToClickable is false", () => {
+    const result = findBestMatch([textChild, clickableParent], "Products", { walkToClickable: false });
+    expect(result).not.toBeNull();
+    expect(result!.element).toBe(textChild);
+    expect(result!.reason).not.toContain("via clickable ancestor");
+  });
+
+  it("returns matched element directly when it is itself clickable", () => {
+    const directButton = makeTestElement({ text: "Save", clickable: true });
+    const result = findBestMatch([directButton], "Save");
+    expect(result).not.toBeNull();
+    expect(result!.element).toBe(directButton);
+    expect(result!.reason).not.toContain("via clickable ancestor");
+  });
+
+  it("falls back to original match when no clickable ancestor exists", () => {
+    const result = findBestMatch([textChild], "Products");
+    expect(result).not.toBeNull();
+    expect(result!.element).toBe(textChild);
   });
 });
 

--- a/src/adb/ui-parser.ts
+++ b/src/adb/ui-parser.ts
@@ -655,9 +655,46 @@ function getShortId(resourceId: string): string {
  * Find best element by description (smart fuzzy search)
  * Returns the best match or null
  */
+/**
+ * Find the smallest clickable ancestor whose bounds fully contain the target element.
+ * Useful for grid/list items where the visible label (TextView) is non-clickable but
+ * the parent ViewGroup carries the TapGestureRecognizer.
+ *
+ * Returns null if no clickable ancestor exists, or if the only candidate is so large
+ * it likely covers the whole screen (heuristic: >75% of any screen dimension).
+ */
+export function findClickableAncestor(
+  target: UiElement,
+  all: UiElement[],
+  options?: { maxAreaMultiplier?: number }
+): UiElement | null {
+  if (target.clickable) return null; // already clickable, no walk needed
+  const targetArea = Math.max(1, target.width * target.height);
+  const maxAreaMultiplier = options?.maxAreaMultiplier ?? 200; // ancestor area ≤ 200× target
+  const candidates = all.filter(el =>
+    el !== target &&
+    el.clickable &&
+    el.enabled &&
+    el.width > 0 &&
+    el.height > 0 &&
+    // bounds containment
+    el.bounds.x1 <= target.bounds.x1 &&
+    el.bounds.y1 <= target.bounds.y1 &&
+    el.bounds.x2 >= target.bounds.x2 &&
+    el.bounds.y2 >= target.bounds.y2 &&
+    // not the whole-screen container
+    el.width * el.height <= targetArea * maxAreaMultiplier
+  );
+  if (candidates.length === 0) return null;
+  // smallest by area = most specific ancestor
+  candidates.sort((a, b) => (a.width * a.height) - (b.width * b.height));
+  return candidates[0];
+}
+
 export function findBestMatch(
   elements: UiElement[],
-  description: string
+  description: string,
+  options?: { walkToClickable?: boolean }
 ): { element: UiElement; confidence: number; reason: string } | null {
   const desc = description.toLowerCase().trim();
 
@@ -723,6 +760,23 @@ export function findBestMatch(
   }
 
   const best = scored[0];
+
+  // If matched element isn't clickable, try walking up to a clickable ancestor.
+  // Common pattern: grid/list item where visible label is a TextView but the parent
+  // ViewGroup owns the TapGestureRecognizer (frequent in MAUI/Compose layouts).
+  // Default ON; caller can opt out with walkToClickable: false.
+  const walkToClickable = options?.walkToClickable ?? true;
+  if (walkToClickable && !best.element.clickable) {
+    const ancestor = findClickableAncestor(best.element, elements);
+    if (ancestor) {
+      return {
+        element: ancestor,
+        confidence: Math.min(best.score, 95),
+        reason: `${best.reason} (via clickable ancestor)`
+      };
+    }
+  }
+
   return {
     element: best.element,
     confidence: Math.min(best.score, 100),

--- a/src/tools/app-tools.test.ts
+++ b/src/tools/app-tools.test.ts
@@ -106,6 +106,48 @@ describe("app_stop", () => {
 });
 
 // ──────────────────────────────────────────────
+// app_restart — stop+launch sequence
+// ──────────────────────────────────────────────
+
+describe("app_restart", () => {
+  const handler = findHandler("app_restart");
+
+  it("throws INVALID_PACKAGE_NAME for package with injection", async () => {
+    const ctx = makeMockContext();
+    await expect(handler({ package: "com.example;rm" }, ctx)).rejects.toThrow(MobileError);
+  });
+
+  it("calls stopApp then launchApp in order with default 500ms delay", async () => {
+    const stopSpy = vi.fn();
+    const launchSpy = vi.fn(() => "launched");
+    const ctx = makeMockContext({
+      deviceManager: {
+        stopApp: stopSpy,
+        launchApp: launchSpy,
+        installApp: vi.fn(() => "installed"),
+        getCurrentPlatform: vi.fn(() => "android"),
+        getAuroraClient: vi.fn(() => ({ listPackages: vi.fn(() => []) })),
+      } as any,
+    });
+    const result = await handler({ package: "com.android.settings", delayMs: 0 }, ctx);
+    expect(stopSpy).toHaveBeenCalledWith("com.android.settings", undefined);
+    expect(launchSpy).toHaveBeenCalledWith("com.android.settings", undefined);
+    // stop must precede launch
+    expect(stopSpy.mock.invocationCallOrder[0]).toBeLessThan(launchSpy.mock.invocationCallOrder[0]);
+    expect(result).toEqual({ text: "Restarted: com.android.settings (delay=0ms). launched" });
+  });
+
+  it("clamps delayMs to 10000ms max", async () => {
+    const ctx = makeMockContext();
+    const start = Date.now();
+    // Use 0 to keep test fast but verify clamping logic via output
+    const result = await handler({ package: "com.android.settings", delayMs: 99999 }, ctx);
+    // Output reports clamped value, not input
+    expect((result as { text: string }).text).toContain("delay=10000ms");
+  }, 15000);
+});
+
+// ──────────────────────────────────────────────
 // app_install — path traversal prevention
 // ──────────────────────────────────────────────
 

--- a/src/tools/app-tools.ts
+++ b/src/tools/app-tools.ts
@@ -66,6 +66,34 @@ export const appTools: ToolDefinition[] = [
   },
   {
     tool: {
+      name: "app_restart",
+      description: "Force-stop then re-launch an app. Common pattern for clearing in-memory state without uninstall.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          package: { type: "string", description: "Package name (Android) or bundle ID (iOS)" },
+          delayMs: { type: "number", description: "Delay between stop and launch in ms (default: 500). Useful so OS releases resources.", default: 500 },
+          platform: { type: "string", enum: ["android", "ios", "desktop", "aurora", "browser"], description: "Target platform. If not specified, uses the active target." },
+        },
+        required: ["package"],
+      },
+    },
+    handler: async (args, ctx) => {
+      const platform = args.platform as Platform | undefined;
+      const pkg = args.package as string;
+      validatePackageName(pkg);
+      const delayMs = Math.max(0, Math.min((args.delayMs as number) ?? 500, 10_000));
+
+      ctx.deviceManager.stopApp(pkg, platform);
+      if (delayMs > 0) {
+        await new Promise(resolve => setTimeout(resolve, delayMs));
+      }
+      const launchResult = await ctx.deviceManager.launchApp(pkg, platform);
+      return { text: `Restarted: ${pkg} (delay=${delayMs}ms). ${launchResult}` };
+    },
+  },
+  {
+    tool: {
       name: "app_list",
       description: "List installed apps (Aurora only)",
       inputSchema: {

--- a/src/tools/ui-tools.ts
+++ b/src/tools/ui-tools.ts
@@ -151,12 +151,13 @@ export const uiTools: ToolDefinition[] = [
   {
     tool: {
       name: "ui_find_tap",
-      description: "Fuzzy tap by natural language element description (Android only)",
+      description: "Fuzzy tap by natural language element description (Android only). When the matched element is a non-clickable label (common in grid/list items where the parent ViewGroup owns the gesture), walks up to the smallest containing clickable ancestor by default — set walkToClickable=false to tap the matched element directly.",
       inputSchema: {
         type: "object",
         properties: {
           description: { type: "string", description: "Natural language description of the element to tap, e.g., 'submit button', 'settings', 'back'" },
           minConfidence: { type: "number", description: "Minimum confidence score (0-100) to accept a match (default: 30)", default: 30 },
+          walkToClickable: { type: "boolean", description: "If matched element is non-clickable (e.g., a TextView label), walk up to the smallest containing clickable ancestor. Default true. Set false to tap the matched element directly even if non-clickable (rare).", default: true },
         },
         required: ["description"],
       },
@@ -171,10 +172,11 @@ export const uiTools: ToolDefinition[] = [
 
       const description = requireString(args, "description");
       const minConfidence = getNumber(args, "minConfidence") ?? 30;
+      const walkToClickable = typeof args.walkToClickable === "boolean" ? args.walkToClickable : true;
 
       const { elements: tapElements } = await getUiElements(ctx, "android");
 
-      const match = findBestMatch(tapElements, description);
+      const match = findBestMatch(tapElements, description, { walkToClickable });
 
       if (!match) {
         return { text: `No element found matching "${description}". Try using ui(action:'tree') or ui(action:'analyze') to see available elements.` };


### PR DESCRIPTION
## Summary

Two improvements based on common Android automation pain points encountered while driving a real-world MAUI app:

1. **`app_restart` tool** — convenience wrapper that force-stops then re-launches an app with an optional `delayMs` (default 500, clamped to 10000) between the two operations. Common pattern for clearing in-memory state without uninstalling.

2. **`ui_find_tap` walks up to clickable ancestor by default** — when the best-matched element is a `TextView` (or any non-clickable label) sitting inside a clickable parent `ViewGroup`, the tap on the matched element coordinates often silently no-ops because Android dispatches the touch to the most specific element, which has no click listener. Extremely common in MAUI/Compose layouts where the visible label has no gesture handler but the parent row/card does.

   New behavior: when `findBestMatch` would return a non-clickable element, walk up to the smallest containing clickable ancestor (bounds-based heuristic, area capped at 200× target to reject screen-root containers). Confidence is slightly reduced (max 95) and reason string suffixed with `(via clickable ancestor)` so callers can detect when the walk happened.

   Default **on** for better out-of-the-box behavior. Opt-out via `walkToClickable: false` for the rare case a caller really wants to tap a non-clickable element directly.

   New helper `findClickableAncestor(target, all, options?)` is also exported for reuse outside `findBestMatch`.

## Real-world motivation

Driving a Samsung Galaxy A53 running a .NET MAUI POS app, every grid icon (Cashier / Products / Categories / Reports / …) has the visible label inside a non-clickable `TextView`, with the `TapGestureRecognizer` on the parent `StackLayout`. Without this change, a natural `ui_find_tap({ description: "Products" })` taps the text and nothing happens. With this change it works as expected.

## Test plan

- [x] 7 new tests for `findClickableAncestor` — containment, area limits, disabled filter, edge cases
- [x] 4 new tests for `findBestMatch` `walkToClickable` — default on, opt-out, already-clickable passthrough, no-ancestor fallback
- [x] 3 new tests for `app_restart` — injection guard, stop-then-launch order, `delayMs` clamping
- [x] Full suite: **753/753 tests pass across 24 test files**, no regressions

## Backward compatibility

- `app_restart` is a new tool, no behavior change for existing tools
- `ui_find_tap` adds an optional `walkToClickable` parameter (default `true`). Existing callers see strictly more useful behavior — when their `description` matched a non-clickable label, the call would have silently no-op'd previously and now it taps the proper ancestor instead. Callers that want strict matching can pass `walkToClickable: false`.