### PR TITLE
feat(scan): inject scannable barcodes into the emulator camera

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,6 +296,30 @@ claude-in-mobile input android "hello world"
 claude-in-mobile ui-dump android | grep "Login"
 ```
 
+#### Camera barcode injection (`scan`, Android emulator)
+
+Feed a real, decodable barcode/QR to the emulator's **back camera** so an app
+actually reads it through its own camera pipeline (CameraX / ML Kit / ZXing) —
+no app changes, no mocking. It uses the emulator's `videofile` camera source to
+play a generated barcode as a full-frame, flat-on feed.
+
+```bash
+# One-time per emulator session: cold-boot the AVD into videofile camera mode
+claude-in-mobile scan "ITEM-12345" --setup
+
+# After that, swapping the code is instant — just reopen the app's scanner screen
+claude-in-mobile scan "ITEM-67890"
+
+# Other symbologies
+claude-in-mobile scan "1234567890" --type code128
+claude-in-mobile scan "590123412345" --type ean13
+```
+
+The barcode is tiled across the frame so a copy always lands inside an app's
+scan region-of-interest. Requires `ffmpeg` on the host (the videofile source
+needs a video stream). The generated video defaults to
+`~/.claude-mobile/scan/feed.mp4` (override with `--video-path`).
+
 #### Coordinate space (raw `x`/`y` in tap / swipe / long_press)
 
 When you call an input tool with raw `x`/`y` (or `x1`/`y1`/`x2`/`y2` for swipe), the values are interpreted in **the most recent screenshot's pixel space** and auto-scaled to device coordinates before dispatch. The scale comes from the last `screen_capture` call: e.g., capture at `preset='low'` (270×480) on a 1080×2400 device sets a 4× factor, so `tap(135, 240)` becomes `tap(540, 960)` on the device.

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -175,7 +175,7 @@ dependencies = [
  "num-traits",
  "pastey",
  "rayon",
- "thiserror",
+ "thiserror 2.0.18",
  "v_frame",
  "y4m",
 ]
@@ -202,6 +202,12 @@ checksum = "375082f007bd67184fb9c0374614b29f9aaa604ec301635f72338bb65386a53d"
 dependencies = [
  "arrayvec",
 ]
+
+[[package]]
+name = "barcoders"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "298326aba91e0dd1acba62767652c7c9f4d45ada6804110278680c4f0c6e8ab7"
 
 [[package]]
 name = "base64"
@@ -345,11 +351,14 @@ version = "3.10.2"
 dependencies = [
  "ab_glyph",
  "anyhow",
+ "barcoders",
  "base64",
  "clap",
  "colored",
+ "dirs",
  "image",
  "imageproc",
+ "qrcode",
  "regex",
  "reqwest",
  "rsa",
@@ -474,6 +483,27 @@ dependencies = [
  "block-buffer",
  "const-oid",
  "crypto-common",
+]
+
+[[package]]
+name = "dirs"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1086,6 +1116,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
+name = "libredox"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f02ab6bace2054fb888a3c16f990117b579d14a3088e472d63c6011fa185c9d3"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1341,6 +1380,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
 name = "owned_ttf_parser"
 version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1481,6 +1526,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "qrcode"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d68782463e408eb1e668cf6152704bd856c78c5b6417adaee3203d8f4c1fc9ec"
+
+[[package]]
 name = "quick-error"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1500,7 +1551,7 @@ dependencies = [
  "rustc-hash",
  "rustls",
  "socket2",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "web-time",
@@ -1521,7 +1572,7 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "slab",
- "thiserror",
+ "thiserror 2.0.18",
  "tinyvec",
  "tracing",
  "web-time",
@@ -1655,7 +1706,7 @@ dependencies = [
  "rand 0.9.2",
  "rand_chacha 0.9.0",
  "simd_helpers",
- "thiserror",
+ "thiserror 2.0.18",
  "v_frame",
  "wasm-bindgen",
 ]
@@ -1699,6 +1750,17 @@ checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
 dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
+dependencies = [
+ "getrandom 0.2.17",
+ "libredox",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -2099,11 +2161,31 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
 version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 2.0.18",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2457,11 +2539,20 @@ checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -2470,7 +2561,7 @@ version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -2484,19 +2575,40 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
+]
+
+[[package]]
+name = "windows-targets"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
  "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
 ]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -2506,9 +2618,21 @@ checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -2524,9 +2648,21 @@ checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -2536,9 +2672,21 @@ checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -19,6 +19,9 @@ colored = "2.0"
 regex = "1.10"
 reqwest = { version = "0.12", features = ["blocking", "json", "multipart", "rustls-tls"], default-features = false }
 rsa = { version = "0.9", features = ["pem", "sha2"] }
+qrcode = { version = "0.14", default-features = false }
+barcoders = "1.0"
+dirs = "5.0"
 
 [dev-dependencies]
 tempfile = "3"

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -1349,8 +1349,11 @@ pub enum Commands {
         /// instead of firing every frame while it sits in frame. The videofile
         /// plays on a global timeline that does not reset on camera reopen, so
         /// the feed must loop for the code to be available whenever the scanner
-        /// opens. Set 0 to keep the barcode visible the whole time (continuous).
-        #[arg(long, default_value = "3.0")]
+        /// opens. Default 0 keeps the barcode visible the whole time so it is
+        /// always there on open (apps that stop after the first decode, like an
+        /// info lookup, scan it once anyway). Use a positive value to throttle
+        /// apps that keep scanning while the code sits in frame.
+        #[arg(long, default_value = "0")]
         hold: f32,
     },
 }

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -1346,8 +1346,9 @@ pub enum Commands {
 
         /// Seconds the barcode stays visible before the feed goes blank, so the
         /// app decodes it once instead of firing continuously while it sits in
-        /// frame. The feed loops, so the code reappears once per loop. Set 0 to
-        /// keep the barcode visible the whole time (continuous scanning).
+        /// frame. A long blank tail follows (~1h), so in practice the code shows
+        /// once and the camera stays quiet. Set 0 to keep the barcode visible
+        /// the whole time (continuous scanning).
         #[arg(long, default_value = "3.0")]
         hold: f32,
     },

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -1303,6 +1303,47 @@ pub enum Commands {
         #[command(subcommand)]
         command: ConfigCommands,
     },
+
+    /// Inject a scannable barcode/QR into the emulator camera (Android emulator only)
+    ///
+    /// Generates a barcode of the requested symbology and feeds it to the
+    /// back camera as a full-frame `videofile` source, so the app under test
+    /// really decodes it via its own camera stack (CameraX / ML Kit / ZXing).
+    ///
+    /// First run on a given emulator needs `--setup` (cold-boots the AVD into
+    /// videofile camera mode). After that, re-running `scan` just swaps the
+    /// image; reopen the app's camera screen to pick up the new code.
+    Scan {
+        /// Text payload to encode (e.g. an item/box code)
+        text: String,
+
+        /// Barcode symbology
+        #[arg(long, default_value = "qr", value_parser = ["qr", "code128", "ean13"])]
+        r#type: String,
+
+        /// Android emulator serial (default: first attached emulator)
+        #[arg(long)]
+        device: Option<String>,
+
+        /// Cold-boot the emulator into videofile camera mode before injecting.
+        /// Required once per emulator session (changes the camera source).
+        #[arg(long, default_value = "false")]
+        setup: bool,
+
+        /// AVD name to (re)launch with `--setup` (auto-detected from the device if omitted)
+        #[arg(long)]
+        avd: Option<String>,
+
+        /// Host path for the managed camera video
+        /// (default: ~/.claude-mobile/scan/feed.mp4)
+        #[arg(long)]
+        video_path: Option<String>,
+
+        /// Tile the barcode across the frame so a copy always lands inside the
+        /// app's scan region-of-interest. Disable for a single centered code.
+        #[arg(long, default_value = "true")]
+        tile: bool,
+    },
 }
 
 // -- Flow subcommands ---------------------------------------------------------

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -1343,6 +1343,13 @@ pub enum Commands {
         /// app's scan region-of-interest. Disable for a single centered code.
         #[arg(long, default_value = "true")]
         tile: bool,
+
+        /// Seconds the barcode stays visible before the feed goes blank, so the
+        /// app decodes it once instead of firing continuously while it sits in
+        /// frame. The feed loops, so the code reappears once per loop. Set 0 to
+        /// keep the barcode visible the whole time (continuous scanning).
+        #[arg(long, default_value = "3.0")]
+        hold: f32,
     },
 }
 

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -1344,11 +1344,12 @@ pub enum Commands {
         #[arg(long, default_value = "true")]
         tile: bool,
 
-        /// Seconds the barcode stays visible before the feed goes blank, so the
-        /// app decodes it once instead of firing continuously while it sits in
-        /// frame. A long blank tail follows (~1h), so in practice the code shows
-        /// once and the camera stays quiet. Set 0 to keep the barcode visible
-        /// the whole time (continuous scanning).
+        /// Seconds the barcode stays visible before the feed goes blank for the
+        /// rest of the 60s loop, so the app decodes it about once per loop
+        /// instead of firing every frame while it sits in frame. The videofile
+        /// plays on a global timeline that does not reset on camera reopen, so
+        /// the feed must loop for the code to be available whenever the scanner
+        /// opens. Set 0 to keep the barcode visible the whole time (continuous).
         #[arg(long, default_value = "3.0")]
         hold: f32,
     },

--- a/cli/src/commands/mod.rs
+++ b/cli/src/commands/mod.rs
@@ -638,6 +638,25 @@ pub fn run(command: Commands) -> Result<()> {
         // -- Sync commands ----------------------------------------------------
         Commands::Sync { command } => sync::run(command),
 
+        // -- Scan (camera barcode injection) ----------------------------------
+        Commands::Scan {
+            text,
+            r#type,
+            device,
+            setup,
+            avd,
+            video_path,
+            tile,
+        } => crate::scan::run(
+            &text,
+            &r#type,
+            device.as_deref(),
+            setup,
+            avd.as_deref(),
+            video_path.as_deref(),
+            tile,
+        ),
+
         // -- Config commands --------------------------------------------------
         Commands::Config { command } => {
             match command {

--- a/cli/src/commands/mod.rs
+++ b/cli/src/commands/mod.rs
@@ -647,6 +647,7 @@ pub fn run(command: Commands) -> Result<()> {
             avd,
             video_path,
             tile,
+            hold,
         } => crate::scan::run(
             &text,
             &r#type,
@@ -655,6 +656,7 @@ pub fn run(command: Commands) -> Result<()> {
             avd.as_deref(),
             video_path.as_deref(),
             tile,
+            hold,
         ),
 
         // -- Config commands --------------------------------------------------

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -10,6 +10,7 @@ mod commands;
 mod desktop;
 mod ios;
 mod scale;
+mod scan;
 mod screenshot;
 mod store;
 

--- a/cli/src/scan.rs
+++ b/cli/src/scan.rs
@@ -30,6 +30,7 @@ pub fn run(
     avd: Option<&str>,
     video_path: Option<&str>,
     tile: bool,
+    hold: f32,
 ) -> Result<()> {
     let serial = resolve_emulator_serial(device)?;
     let video = resolve_video_path(video_path)?;
@@ -44,7 +45,7 @@ pub fn run(
         .save(&png_path)
         .with_context(|| format!("Failed to write frame image {}", png_path.display()))?;
 
-    encode_video(&png_path, &video)?;
+    encode_video(&png_path, &video, hold)?;
 
     if setup {
         setup_emulator(&serial, avd, &video)?;
@@ -231,30 +232,54 @@ fn encode_linear(text: &str, kind: &str) -> Result<Vec<u8>> {
 
 /// Wrap the still barcode image into a short looping MP4 — the emulator's
 /// videofile camera source needs a video stream, not a still image.
-fn encode_video(png: &Path, mp4: &Path) -> Result<()> {
+fn encode_video(png: &Path, mp4: &Path, hold: f32) -> Result<()> {
     which("ffmpeg").context(
         "ffmpeg is required to build the camera video but was not found in PATH.\n\
          Install it (e.g. `brew install ffmpeg`) and retry.",
     )?;
+
+    const TOTAL_SECS: f32 = 60.0;
+    let scale = format!("scale={}:{}", FRAME_W, FRAME_H);
+
+    // hold <= 0 (or >= total) keeps the barcode visible the whole loop: the app
+    // scans it continuously while it sits in frame. Otherwise the barcode shows
+    // for `hold` seconds then the feed goes blank for the rest of the loop, so
+    // the app decodes it once per loop instead of firing every frame.
+    let args: Vec<String> = if hold <= 0.0 || hold >= TOTAL_SECS {
+        vec![
+            "-y".into(),
+            "-loop".into(), "1".into(),
+            "-i".into(), png.to_string_lossy().into_owned(),
+            "-t".into(), TOTAL_SECS.to_string(),
+            "-r".into(), "10".into(),
+            "-g".into(), "10".into(),
+            "-pix_fmt".into(), "yuv420p".into(),
+            "-vf".into(), scale,
+            mp4.to_string_lossy().into_owned(),
+        ]
+    } else {
+        let blank = (TOTAL_SECS - hold).to_string();
+        vec![
+            "-y".into(),
+            "-loop".into(), "1".into(), "-t".into(), hold.to_string(),
+            "-i".into(), png.to_string_lossy().into_owned(),
+            "-f".into(), "lavfi".into(), "-t".into(), blank,
+            "-i".into(), format!("color=c=white:s={}x{}:r=10", FRAME_W, FRAME_H),
+            "-filter_complex".into(),
+            format!(
+                "[0:v]{},setsar=1[a];[1:v]setsar=1[b];[a][b]concat=n=2:v=1:a=0[v]",
+                scale
+            ),
+            "-map".into(), "[v]".into(),
+            "-r".into(), "10".into(),
+            "-g".into(), "10".into(),
+            "-pix_fmt".into(), "yuv420p".into(),
+            mp4.to_string_lossy().into_owned(),
+        ]
+    };
+
     let status = Command::new("ffmpeg")
-        .args([
-            "-y",
-            "-loop",
-            "1",
-            "-i",
-            &png.to_string_lossy(),
-            "-t",
-            "60",
-            "-r",
-            "10",
-            "-g",
-            "10",
-            "-pix_fmt",
-            "yuv420p",
-            "-vf",
-            &format!("scale={}:{}", FRAME_W, FRAME_H),
-            &mp4.to_string_lossy(),
-        ])
+        .args(&args)
         .stdout(Stdio::null())
         .stderr(Stdio::null())
         .status()

--- a/cli/src/scan.rs
+++ b/cli/src/scan.rs
@@ -239,17 +239,16 @@ fn encode_video(png: &Path, mp4: &Path, hold: f32) -> Result<()> {
     )?;
 
     const LOOP_SECS: f32 = 60.0;
-    // The videofile camera source loops the file, so the barcode would reappear
-    // every loop. With `hold`, pad a very long blank tail (~1h) so in practice
-    // the code shows once and the camera stays quiet for the whole session.
-    // Static white compresses to almost nothing, so the file stays small.
-    const BLANK_TAIL_SECS: f32 = 3600.0;
     let scale = format!("scale={}:{}", FRAME_W, FRAME_H);
 
-    // hold <= 0 keeps the barcode visible the whole loop: the app scans it
-    // continuously while it sits in frame. Otherwise the barcode shows for
-    // `hold` seconds then the feed goes blank, so the app decodes it once.
-    let args: Vec<String> = if hold <= 0.0 {
+    // The videofile camera source plays on a global timeline that does NOT reset
+    // on camera reopen, so the file must LOOP for the barcode to be available
+    // whenever the app opens its scanner. hold <= 0 (or >= loop) keeps the
+    // barcode visible the whole loop — the app scans it continuously while it
+    // sits in frame. Otherwise the barcode shows for `hold` seconds then the
+    // feed goes blank for the rest of the loop, so the app decodes it roughly
+    // once per loop instead of every frame.
+    let args: Vec<String> = if hold <= 0.0 || hold >= LOOP_SECS {
         vec![
             "-y".into(),
             "-loop".into(), "1".into(),
@@ -262,7 +261,7 @@ fn encode_video(png: &Path, mp4: &Path, hold: f32) -> Result<()> {
             mp4.to_string_lossy().into_owned(),
         ]
     } else {
-        let blank = BLANK_TAIL_SECS.to_string();
+        let blank = (LOOP_SECS - hold).to_string();
         vec![
             "-y".into(),
             "-loop".into(), "1".into(), "-t".into(), hold.to_string(),

--- a/cli/src/scan.rs
+++ b/cli/src/scan.rs
@@ -238,19 +238,23 @@ fn encode_video(png: &Path, mp4: &Path, hold: f32) -> Result<()> {
          Install it (e.g. `brew install ffmpeg`) and retry.",
     )?;
 
-    const TOTAL_SECS: f32 = 60.0;
+    const LOOP_SECS: f32 = 60.0;
+    // The videofile camera source loops the file, so the barcode would reappear
+    // every loop. With `hold`, pad a very long blank tail (~1h) so in practice
+    // the code shows once and the camera stays quiet for the whole session.
+    // Static white compresses to almost nothing, so the file stays small.
+    const BLANK_TAIL_SECS: f32 = 3600.0;
     let scale = format!("scale={}:{}", FRAME_W, FRAME_H);
 
-    // hold <= 0 (or >= total) keeps the barcode visible the whole loop: the app
-    // scans it continuously while it sits in frame. Otherwise the barcode shows
-    // for `hold` seconds then the feed goes blank for the rest of the loop, so
-    // the app decodes it once per loop instead of firing every frame.
-    let args: Vec<String> = if hold <= 0.0 || hold >= TOTAL_SECS {
+    // hold <= 0 keeps the barcode visible the whole loop: the app scans it
+    // continuously while it sits in frame. Otherwise the barcode shows for
+    // `hold` seconds then the feed goes blank, so the app decodes it once.
+    let args: Vec<String> = if hold <= 0.0 {
         vec![
             "-y".into(),
             "-loop".into(), "1".into(),
             "-i".into(), png.to_string_lossy().into_owned(),
-            "-t".into(), TOTAL_SECS.to_string(),
+            "-t".into(), LOOP_SECS.to_string(),
             "-r".into(), "10".into(),
             "-g".into(), "10".into(),
             "-pix_fmt".into(), "yuv420p".into(),
@@ -258,7 +262,7 @@ fn encode_video(png: &Path, mp4: &Path, hold: f32) -> Result<()> {
             mp4.to_string_lossy().into_owned(),
         ]
     } else {
-        let blank = (TOTAL_SECS - hold).to_string();
+        let blank = BLANK_TAIL_SECS.to_string();
         vec![
             "-y".into(),
             "-loop".into(), "1".into(), "-t".into(), hold.to_string(),

--- a/cli/src/scan.rs
+++ b/cli/src/scan.rs
@@ -1,0 +1,397 @@
+//! `scan` command — inject a scannable barcode/QR into the Android emulator camera.
+//!
+//! The emulator's hidden `videofile` camera source plays back a video file as a
+//! full-frame, flat-on camera feed. Feeding it a barcode makes the app under
+//! test decode the code through its own camera pipeline (CameraX / ML Kit /
+//! ZXing) — no app changes, no mocking.
+//!
+//! Switching the camera source is a boot-time setting, so the first run on a
+//! given emulator needs `--setup` (cold-boots the AVD into videofile mode).
+//! Subsequent runs only rewrite the video; reopen the app's camera screen to
+//! load the new code.
+
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+use std::thread::sleep;
+use std::time::{Duration, Instant};
+
+use anyhow::{bail, Context, Result};
+use image::{imageops, Rgb, RgbImage};
+
+const FRAME_W: u32 = 640;
+const FRAME_H: u32 = 480;
+
+/// Entry point for the `scan` subcommand.
+pub fn run(
+    text: &str,
+    kind: &str,
+    device: Option<&str>,
+    setup: bool,
+    avd: Option<&str>,
+    video_path: Option<&str>,
+    tile: bool,
+) -> Result<()> {
+    let serial = resolve_emulator_serial(device)?;
+    let video = resolve_video_path(video_path)?;
+    if let Some(dir) = video.parent() {
+        std::fs::create_dir_all(dir)
+            .with_context(|| format!("Failed to create directory {}", dir.display()))?;
+    }
+
+    let frame = render_frame(text, kind, tile)?;
+    let png_path = video.with_extension("png");
+    frame
+        .save(&png_path)
+        .with_context(|| format!("Failed to write frame image {}", png_path.display()))?;
+
+    encode_video(&png_path, &video)?;
+
+    if setup {
+        setup_emulator(&serial, avd, &video)?;
+        println!(
+            "Camera set to videofile mode and emulator booted.\n\
+             Injected {} \"{}\" -> {}\n\
+             Open the app's camera/scanner screen to scan it.",
+            kind, text, video.display()
+        );
+    } else {
+        let active = emulator_uses_videofile(&video);
+        println!("Injected {} \"{}\" -> {}", kind, text, video.display());
+        if active {
+            println!("Reopen the app's camera/scanner screen to load the new code.");
+        } else {
+            println!(
+                "WARNING: this emulator does not appear to be running in videofile \
+                 camera mode for that path.\n\
+                 Run once with `--setup` to cold-boot it into the right mode:\n  \
+                 claude-in-mobile scan \"{}\" --type {} --setup",
+                text, kind
+            );
+        }
+    }
+
+    Ok(())
+}
+
+// -- Path / device resolution -------------------------------------------------
+
+fn resolve_video_path(explicit: Option<&str>) -> Result<PathBuf> {
+    if let Some(p) = explicit {
+        let mut path = PathBuf::from(p);
+        if path.extension().is_none() {
+            path.set_extension("mp4");
+        }
+        return Ok(path);
+    }
+    let base = dirs::home_dir().context("Could not determine home directory")?;
+    Ok(base.join(".claude-mobile").join("scan").join("feed.mp4"))
+}
+
+/// Pick the target emulator serial: the explicit one, or the first `emulator-*`
+/// device reported by adb.
+fn resolve_emulator_serial(device: Option<&str>) -> Result<String> {
+    if let Some(d) = device {
+        return Ok(d.to_string());
+    }
+    let out = Command::new("adb")
+        .arg("devices")
+        .output()
+        .context("Failed to run `adb devices` (is adb installed?)")?;
+    let text = String::from_utf8_lossy(&out.stdout);
+    for line in text.lines().skip(1) {
+        let mut parts = line.split_whitespace();
+        if let (Some(serial), Some(state)) = (parts.next(), parts.next()) {
+            if state == "device" && serial.starts_with("emulator-") {
+                return Ok(serial.to_string());
+            }
+        }
+    }
+    bail!("No running Android emulator found. Start one, or pass --device <serial>.")
+}
+
+// -- Barcode rendering --------------------------------------------------------
+
+fn render_frame(text: &str, kind: &str, tile: bool) -> Result<RgbImage> {
+    match kind {
+        "qr" => Ok(render_qr_frame(text, tile)?),
+        "code128" | "ean13" => Ok(render_linear_frame(text, kind)?),
+        other => bail!("Unsupported barcode type: {}", other),
+    }
+}
+
+/// Render a single QR tile (modules + quiet zone) at `module_px` per module.
+fn render_qr_tile(text: &str, module_px: u32, quiet: u32) -> Result<RgbImage> {
+    use qrcode::{Color, QrCode};
+    let code = QrCode::new(text.as_bytes()).context("Failed to build QR code")?;
+    let modules = code.width() as u32;
+    let colors = code.to_colors();
+    let side = (modules + 2 * quiet) * module_px;
+    let mut img = RgbImage::from_pixel(side, side, Rgb([255, 255, 255]));
+    for my in 0..modules {
+        for mx in 0..modules {
+            if colors[(my * modules + mx) as usize] == Color::Dark {
+                let px0 = (mx + quiet) * module_px;
+                let py0 = (my + quiet) * module_px;
+                for dy in 0..module_px {
+                    for dx in 0..module_px {
+                        img.put_pixel(px0 + dx, py0 + dy, Rgb([0, 0, 0]));
+                    }
+                }
+            }
+        }
+    }
+    Ok(img)
+}
+
+/// Build the camera frame for a QR code. When tiling, a 3x2 grid of identical
+/// codes is laid out so at least one copy always falls inside the app's scan
+/// region-of-interest (some apps only analyze part of the frame).
+fn render_qr_frame(text: &str, tile: bool) -> Result<RgbImage> {
+    let mut canvas = RgbImage::from_pixel(FRAME_W, FRAME_H, Rgb([255, 255, 255]));
+    let qr = render_qr_tile(text, 4, 4)?;
+
+    if tile {
+        let cols = 3u32;
+        let rows = 2u32;
+        let cell = 150u32;
+        let gap = 12u32;
+        let grid_w = cols * cell + (cols + 1) * gap;
+        let grid_h = rows * cell + (rows + 1) * gap;
+        let ox = (FRAME_W - grid_w) / 2;
+        let oy = (FRAME_H - grid_h) / 2;
+        let small = imageops::resize(&qr, cell, cell, imageops::FilterType::Nearest);
+        for r in 0..rows {
+            for c in 0..cols {
+                let x = (ox + gap + c * (cell + gap)) as i64;
+                let y = (oy + gap + r * (cell + gap)) as i64;
+                imageops::overlay(&mut canvas, &small, x, y);
+            }
+        }
+    } else {
+        let side = 384u32;
+        let big = imageops::resize(&qr, side, side, imageops::FilterType::Nearest);
+        let x = ((FRAME_W - side) / 2) as i64;
+        let y = ((FRAME_H - side) / 2) as i64;
+        imageops::overlay(&mut canvas, &big, x, y);
+    }
+    Ok(canvas)
+}
+
+/// Build the camera frame for a 1D barcode (Code128 / EAN13). Two stacked
+/// copies cover both halves of the frame so the code is found regardless of
+/// which region the app analyzes.
+fn render_linear_frame(text: &str, kind: &str) -> Result<RgbImage> {
+    let bars = encode_linear(text, kind)?;
+    let mut canvas = RgbImage::from_pixel(FRAME_W, FRAME_H, Rgb([255, 255, 255]));
+
+    let quiet = 40u32;
+    let usable = FRAME_W - 2 * quiet;
+    let bar_px = (usable / bars.len() as u32).max(1);
+    let bw = bar_px * bars.len() as u32;
+    let x0 = (FRAME_W - bw) / 2;
+    let bar_h = 150u32;
+
+    for (i, copy_y) in [110u32, 330u32].into_iter().enumerate() {
+        let _ = i;
+        for (bi, b) in bars.iter().enumerate() {
+            if *b == 1 {
+                let bx = x0 + bi as u32 * bar_px;
+                for dx in 0..bar_px {
+                    for dy in 0..bar_h {
+                        canvas.put_pixel(bx + dx, copy_y + dy, Rgb([0, 0, 0]));
+                    }
+                }
+            }
+        }
+    }
+    Ok(canvas)
+}
+
+fn encode_linear(text: &str, kind: &str) -> Result<Vec<u8>> {
+    match kind {
+        "code128" => {
+            use barcoders::sym::code128::Code128;
+            // Prefix selects Code Set B (full ASCII): U+0181.
+            let data = format!("\u{0181}{}", text);
+            let code = Code128::new(data)
+                .map_err(|e| anyhow::anyhow!("Invalid Code128 payload: {:?}", e))?;
+            Ok(code.encode())
+        }
+        "ean13" => {
+            use barcoders::sym::ean13::EAN13;
+            let code = EAN13::new(text)
+                .map_err(|e| anyhow::anyhow!("Invalid EAN13 payload (need 12-13 digits): {:?}", e))?;
+            Ok(code.encode())
+        }
+        other => bail!("Unsupported linear type: {}", other),
+    }
+}
+
+// -- Video encoding -----------------------------------------------------------
+
+/// Wrap the still barcode image into a short looping MP4 — the emulator's
+/// videofile camera source needs a video stream, not a still image.
+fn encode_video(png: &Path, mp4: &Path) -> Result<()> {
+    which("ffmpeg").context(
+        "ffmpeg is required to build the camera video but was not found in PATH.\n\
+         Install it (e.g. `brew install ffmpeg`) and retry.",
+    )?;
+    let status = Command::new("ffmpeg")
+        .args([
+            "-y",
+            "-loop",
+            "1",
+            "-i",
+            &png.to_string_lossy(),
+            "-t",
+            "60",
+            "-r",
+            "10",
+            "-g",
+            "10",
+            "-pix_fmt",
+            "yuv420p",
+            "-vf",
+            &format!("scale={}:{}", FRAME_W, FRAME_H),
+            &mp4.to_string_lossy(),
+        ])
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .context("Failed to run ffmpeg")?;
+    if !status.success() {
+        bail!("ffmpeg failed to encode {}", mp4.display());
+    }
+    Ok(())
+}
+
+// -- Emulator setup (cold boot into videofile mode) ---------------------------
+
+fn setup_emulator(serial: &str, avd: Option<&str>, video: &Path) -> Result<()> {
+    let avd_name = match avd {
+        Some(a) => a.to_string(),
+        None => detect_avd_name(serial)?,
+    };
+    let emu_bin = find_emulator_binary()?;
+
+    // Stop the running emulator so the new camera source takes effect.
+    let _ = Command::new("adb")
+        .args(["-s", serial, "emu", "kill"])
+        .output();
+    wait_until_gone(serial, Duration::from_secs(40));
+
+    let camera_arg = format!("videofile:{}", video.display());
+    Command::new(&emu_bin)
+        .args([
+            "-avd",
+            &avd_name,
+            "-feature",
+            "VideoPlayback",
+            "-camera-back",
+            &camera_arg,
+            "-no-snapshot-load",
+            "-gpu",
+            "host",
+            "-no-boot-anim",
+            "-netdelay",
+            "none",
+            "-netspeed",
+            "full",
+        ])
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .with_context(|| format!("Failed to launch emulator binary {}", emu_bin.display()))?;
+
+    wait_until_booted(serial, Duration::from_secs(180))?;
+    Ok(())
+}
+
+fn detect_avd_name(serial: &str) -> Result<String> {
+    let out = Command::new("adb")
+        .args(["-s", serial, "emu", "avd", "name"])
+        .output()
+        .context("Failed to query AVD name")?;
+    let text = String::from_utf8_lossy(&out.stdout);
+    let name = text.lines().next().unwrap_or("").trim();
+    if name.is_empty() || name == "KO" {
+        bail!("Could not detect AVD name for {serial}; pass --avd <name>.");
+    }
+    Ok(name.to_string())
+}
+
+fn find_emulator_binary() -> Result<PathBuf> {
+    for var in ["ANDROID_HOME", "ANDROID_SDK_ROOT"] {
+        if let Ok(root) = std::env::var(var) {
+            let candidate = PathBuf::from(root).join("emulator").join("emulator");
+            if candidate.exists() {
+                return Ok(candidate);
+            }
+        }
+    }
+    if which("emulator").is_ok() {
+        return Ok(PathBuf::from("emulator"));
+    }
+    bail!("Could not find the `emulator` binary. Set ANDROID_HOME or add it to PATH.")
+}
+
+fn wait_until_gone(serial: &str, timeout: Duration) {
+    let start = Instant::now();
+    while start.elapsed() < timeout {
+        let out = Command::new("adb").args(["-s", serial, "get-state"]).output();
+        match out {
+            Ok(o) if o.status.success() => sleep(Duration::from_millis(500)),
+            _ => return,
+        }
+    }
+}
+
+fn wait_until_booted(serial: &str, timeout: Duration) -> Result<()> {
+    let start = Instant::now();
+    let _ = Command::new("adb")
+        .args(["-s", serial, "wait-for-device"])
+        .output();
+    while start.elapsed() < timeout {
+        let out = Command::new("adb")
+            .args(["-s", serial, "shell", "getprop", "sys.boot_completed"])
+            .output();
+        if let Ok(o) = out {
+            if String::from_utf8_lossy(&o.stdout).trim() == "1" {
+                return Ok(());
+            }
+        }
+        sleep(Duration::from_secs(2));
+    }
+    bail!("Emulator did not finish booting within {:?}", timeout)
+}
+
+/// Best-effort check that some running emulator process uses our videofile path.
+fn emulator_uses_videofile(video: &Path) -> bool {
+    let needle = format!("videofile:{}", video.display());
+    let out = Command::new("ps").args(["-ax", "-o", "command="]).output();
+    if let Ok(o) = out {
+        if String::from_utf8_lossy(&o.stdout).contains(&needle) {
+            return true;
+        }
+    }
+    // Linux-style fallback.
+    if let Ok(o) = Command::new("ps").args(["-e", "-o", "args="]).output() {
+        return String::from_utf8_lossy(&o.stdout).contains(&needle);
+    }
+    false
+}
+
+fn which(bin: &str) -> Result<()> {
+    let status = Command::new("which")
+        .arg(bin)
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .context("Failed to run `which`")?;
+    if status.success() {
+        Ok(())
+    } else {
+        bail!("{} not found", bin)
+    }
+}


### PR DESCRIPTION
## What

Adds a `scan` subcommand that injects a real, decodable barcode/QR into the
Android emulator's back camera, so an app under test reads it through its own
camera pipeline (CameraX / ML Kit / ZXing) — no app changes, no mocking.

```
claude-in-mobile scan <text> [--type qr|code128|ean13] [--device <id>]
                              [--setup] [--avd <name>] [--video-path <path>] [--tile]
```

## How it works

The emulator exposes a (feature-gated) `videofile` camera source that plays a
video file as a full-frame, flat-on camera feed. `scan` generates a barcode of
the requested symbology, wraps it into a short looping MP4 (ffmpeg), and serves
it as the back camera.

- `--setup` cold-boots the AVD into videofile mode with the `VideoPlayback`
  feature enabled (the camera source is a boot-time setting). It auto-detects
  the AVD name and the `emulator` binary.
- Subsequent runs hot-swap the code with no reboot — reopen the app's camera
  screen to load it.
- The barcode is tiled across the frame by default so a copy always lands inside
  an app's scan region-of-interest (some apps only analyze part of the frame).

## Symbologies

`qr` (default, via `qrcode`), `code128` and `ean13` (via `barcoders`). Matrices/
bars are drawn with the existing `image` crate, so no image-version churn.

## Requirements

- Android emulator (any AVD); `--setup` switches it to videofile camera mode.
- `ffmpeg` on the host (the videofile source needs a video stream).

## Testing

1. `claude-in-mobile scan "TEST-123" --setup`
2. Open any QR/barcode scanner app on the emulator → it decodes `TEST-123`.
3. `claude-in-mobile scan "TEST-456"` → reopen the scanner → it decodes `TEST-456`.

Verified end-to-end against a production CameraX + ML Kit scanner screen: the
injected payload decoded and the app rendered the matching backend record.

## Notes

- Default video path: `~/.claude-mobile/scan/feed.mp4` (override `--video-path`).
- Implementation lives in `cli/src/scan.rs`; wired through the existing
  clap/dispatch/anyhow conventions.
