### PR TITLE
fix(tools): emit draft 2020-12 JSON Schema so the Anthropic API accepts the tool list

### DIFF
--- a/src/tools/define-tool.ts
+++ b/src/tools/define-tool.ts
@@ -35,8 +35,15 @@ export interface DefineToolOptions<S extends z.ZodTypeAny> {
 export function defineTool<S extends z.ZodTypeAny>(
   opts: DefineToolOptions<S>,
 ): ToolDefinition {
+  // MUST stay "draft-2020-12": the Anthropic Messages API validates every
+  // `tools[].custom.input_schema` against the JSON Schema draft 2020-12
+  // meta-schema and rejects the whole request with HTTP 400 otherwise.
+  // Under "draft-7" zod emits the tuple form `items: [schemaA, schemaB]`
+  // for `z.tuple(...)`, which 2020-12 removed in favour of `prefixItems`
+  // (`items` there is `{"$dynamicRef": "#meta"}` — a schema, not an array).
+  // See src/tools/schema-dialect.test.ts for the regression guard.
   const json = z.toJSONSchema(opts.schema, {
-    target: "draft-7",
+    target: "draft-2020-12",
   }) as Record<string, unknown>;
 
   const tool: Tool = {

--- a/src/tools/schema-dialect.test.ts
+++ b/src/tools/schema-dialect.test.ts
@@ -1,0 +1,114 @@
+/**
+ * JSON Schema dialect invariant for advertised tool schemas.
+ *
+ * The Anthropic Messages API validates every `tools[].custom.input_schema`
+ * against the JSON Schema draft 2020-12 meta-schema. One draft-07-only
+ * construct anywhere in the catalogue rejects the ENTIRE request with
+ * HTTP 400 (`tools.N.custom.input_schema: JSON schema is invalid`) — the MCP
+ * server then contributes nothing to that client, so the blast radius is the
+ * whole connection, not the one offending tool.
+ *
+ * v3.15.0 shipped exactly that: `input.waypoints` uses `z.tuple([...])`, and
+ * `defineTool` was generating schemas with `target: "draft-7"`, where zod
+ * emits the tuple form `items: [schemaA, schemaB]`. Draft 2020-12 defines
+ * `items` as `{"$dynamicRef": "#meta"}` — a schema, never an array — and moved
+ * positional schemas to `prefixItems`.
+ *
+ * Hidden meta tools are checked too: they become visible via
+ * `device(enable_module:…)`, so a bad schema there surfaces later and looks
+ * unrelated to the module that introduced it.
+ */
+
+import { describe, expect, it } from "vitest";
+import { z } from "zod";
+import { defineTool } from "./define-tool.js";
+import { META_TOOL_DESCRIPTORS } from "./meta/index.js";
+
+/**
+ * Collect JSON pointers to constructs that are valid in draft-07 but rejected
+ * by the draft 2020-12 meta-schema.
+ */
+function findDraft7OnlyForms(
+  node: unknown,
+  path: string,
+  out: string[] = [],
+): string[] {
+  if (Array.isArray(node)) {
+    node.forEach((item, i) => findDraft7OnlyForms(item, `${path}[${i}]`, out));
+    return out;
+  }
+  if (node === null || typeof node !== "object") return out;
+
+  for (const [key, value] of Object.entries(node as Record<string, unknown>)) {
+    const child = `${path}.${key}`;
+
+    if (key === "items" && Array.isArray(value)) {
+      out.push(`${child} — tuple form of "items"; 2020-12 wants "prefixItems"`);
+    }
+    if (key === "additionalItems") {
+      out.push(`${child} — "additionalItems" was removed in 2020-12`);
+    }
+
+    // Property names are arbitrary user keys, so a property literally called
+    // "items" or "additionalItems" must not be mistaken for a keyword.
+    if (key === "properties" && value !== null && typeof value === "object") {
+      for (const [prop, subSchema] of Object.entries(
+        value as Record<string, unknown>,
+      )) {
+        findDraft7OnlyForms(subSchema, `${child}.${prop}`, out);
+      }
+      continue;
+    }
+
+    findDraft7OnlyForms(value, child, out);
+  }
+
+  return out;
+}
+
+describe("advertised tool schemas are draft 2020-12 clean", () => {
+  it.each(META_TOOL_DESCRIPTORS.map((d) => [d.name, d] as const))(
+    "%s",
+    (_name, descriptor) => {
+      const violations = findDraft7OnlyForms(
+        descriptor.meta.tool.inputSchema,
+        descriptor.name,
+      );
+      expect(violations).toEqual([]);
+    },
+  );
+});
+
+describe("defineTool emits the 2020-12 dialect", () => {
+  // Guards the invariant directly, so the suite above cannot go green merely
+  // because no tool happens to use a tuple at the moment.
+  const probe = defineTool({
+    name: "schema_dialect_probe",
+    description: "Probe tool used to assert the emitted JSON Schema dialect.",
+    schema: z.object({
+      waypoints: z.array(z.tuple([z.number(), z.number()])).optional(),
+    }),
+    handler: async () => ({ text: "ok" }),
+  });
+
+  const waypoints = (
+    probe.tool.inputSchema as {
+      properties: Record<string, { items?: unknown }>;
+    }
+  ).properties.waypoints;
+
+  it("encodes tuples as prefixItems, not as an array of schemas", () => {
+    const inner = waypoints.items as {
+      items?: unknown;
+      prefixItems?: unknown[];
+    };
+    expect(Array.isArray(inner.items)).toBe(false);
+    expect(inner.prefixItems).toHaveLength(2);
+  });
+
+  it("leaves no draft-07-only construct in the generated schema", () => {
+    expect(
+      findDraft7OnlyForms(probe.tool.inputSchema, "schema_dialect_probe"),
+    ).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Symptom

With `claude-in-mobile@3.15.0` configured as an MCP server, every Claude Code
session fails at startup:

```
API Error: 400 tools.218.custom.input_schema: JSON schema is invalid.
It must match JSON Schema draft 2020-12
```

The failure is not scoped to one tool — the whole `messages` request is
rejected, so the server contributes **zero** tools to the client. `3.14.0` is
unaffected; this is a `3.15.0` regression.

## Cause

`src/tools/define-tool.ts` generated every advertised schema with

```ts
z.toJSONSchema(opts.schema, { target: "draft-7" })
```

That was harmless while no tool used `z.tuple`. `3.15.0` added
`input(action: "drag")` with

```ts
waypoints: z.array(z.tuple([z.number(), z.number()]))   // src/tools/interaction-tools.ts
```

for which zod (4.4.3) emits the draft-07 tuple form:

```json
"waypoints": {
  "type": "array",
  "items": { "type": "array", "items": [{ "type": "number" }, { "type": "number" }] }
}
```

Draft 2020-12 removed that form. In the applicator meta-schema `items` is a
schema, never an array, and positional schemas moved to `prefixItems`:

```json
"items":       { "$dynamicRef": "#meta" },
"prefixItems": { "$ref": "#/$defs/schemaArray" }
```

— <https://json-schema.org/draft/2020-12/meta/applicator>, listed as one of the
two breaking changes in the
[release notes](https://json-schema.org/draft/2020-12/release-notes). The
Anthropic API validates `tools[].custom.input_schema` against exactly this
meta-schema.

## Fix

Switch the emit target to `"draft-2020-12"` (8-line diff including an inline
comment explaining why the target must not drift back).

Measured over all 21 `META_TOOL_DESCRIPTORS` (hidden modules included) and
against a `tools/list` dump from a live stdio server:

- draft-07-only constructs: **1 before → 0 after** (the single offender being
  `input.properties.waypoints.items.items`);
- of the 14 visible tools, the dialect change rewrote **one line in one
  schema** (`items` → `prefixItems` under `input.waypoints`); the other 13
  schemas are byte-identical;
- `3.14.0` has no violations, confirming the regression window.

Fixing the dialect rather than rewriting `waypoints` as
`z.array(z.number()).length(2)` also covers every future `z.tuple` usage.

## Regression test

`src/tools/schema-dialect.test.ts` walks every descriptor in
`META_TOOL_DESCRIPTORS` — including tools only reachable through
`device(enable_module: …)`, where a bad schema would otherwise surface much
later and look unrelated — and asserts no `items`-as-array / `additionalItems`
remains. Because a green run would otherwise prove nothing if no tool happened
to use a tuple, it also builds a probe `defineTool` with `z.tuple` and pins the
emitted dialect directly.

The guard was verified to fail on the bug: reverting `define-tool.ts` to
`target: "draft-7"` turns exactly three cases red — the `input` descriptor case
and both probe cases — and they go green again with the fix in place.

## Verification

- `npm test` — 58 files, 1304 tests, all passing.
- `npx vitest run src/tools/schema-dialect.test.ts` — 23 passing (21 descriptors + 2 probes).
- `npm run build` / `npx tsc --noEmit` — clean.

## Release note

`package.json` and `CHANGELOG.md` are deliberately untouched — the release
pipeline is yours. This does look like a `3.15.1` candidate: `3.15.0` as
published on npm is unusable for any Anthropic API client, since the server
advertises no tools at all.

No upstream issue exists for this (searched for `input_schema`, `prefixItems`,
`draft 2020-12` — 0 results).
