### PR TITLE
fix(wda): correct the WebDriverAgent simulator build path

### DIFF
--- a/packages/plugin-ios/src/ios/wda/wda-build.test.ts
+++ b/packages/plugin-ios/src/ios/wda/wda-build.test.ts
@@ -13,7 +13,6 @@ import { WDAManager } from "./wda-manager.js";
 
 interface BuildHarness {
   derivedDataRoot: string;
-  buildTimeout: number;
   buildWDAIfNeeded(wdaPath: string): Promise<void>;
 }
 
@@ -36,7 +35,6 @@ describe("WDAManager build path", () => {
   let derivedDataRoot: string;
   let buildArgsLog: string;
   let devicesJson: string;
-  let listappsOut: string;
   let savedPath: string | undefined;
 
   beforeEach(() => {
@@ -45,7 +43,6 @@ describe("WDAManager build path", () => {
     derivedDataRoot = join(workDir, "DerivedData");
     buildArgsLog = join(workDir, "xcodebuild-args");
     devicesJson = join(workDir, "devices.json");
-    listappsOut = join(workDir, "listapps.txt");
 
     mkdirSync(join(wdaPath, "WebDriverAgent.xcodeproj"), { recursive: true });
     // appium-webdriveragent ships `build/` as its TypeScript output — always present,
@@ -58,11 +55,7 @@ describe("WDAManager build path", () => {
     writeFileSync(join(bin, "xcodebuild"), `#!/bin/sh\necho "$@" > "${buildArgsLog}"\nexit 0\n`);
     chmodSync(join(bin, "xcodebuild"), 0o755);
     writeFileSync(devicesJson, DEVICES_JSON);
-    writeFileSync(listappsOut, "");
-    writeFileSync(
-      join(bin, "xcrun"),
-      `#!/bin/sh\ncase "$*" in\n  *listapps*) cat "${listappsOut}" ;;\n  *) cat "${devicesJson}" ;;\nesac\n`,
-    );
+    writeFileSync(join(bin, "xcrun"), `#!/bin/sh\ncat "${devicesJson}"\n`);
     chmodSync(join(bin, "xcrun"), 0o755);
 
     savedPath = process.env.PATH;
@@ -123,5 +116,19 @@ describe("WDAManager build path", () => {
     await harness(manager).buildWDAIfNeeded(wdaPath);
 
     expect(readFileSync(buildArgsLog, "utf8")).toContain("CODE_SIGNING_ALLOWED=NO");
+  });
+
+  // A cold `build-for-testing` writes ~1 MB of progress to stdout; execSync's default
+  // maxBuffer is exactly that, and Node SIGTERMs the child once it is exceeded.
+  it("survives a build whose output exceeds the default execSync buffer", async () => {
+    writeFileSync(
+      join(workDir, "bin", "xcodebuild"),
+      `#!/bin/sh\nawk 'BEGIN { for (i = 0; i < 40000; i++) print "xcodebuild progress line padding" }'\nexit 0\n`,
+    );
+    chmodSync(join(workDir, "bin", "xcodebuild"), 0o755);
+    const manager = new WDAManager();
+    harness(manager).derivedDataRoot = derivedDataRoot;
+
+    await expect(harness(manager).buildWDAIfNeeded(wdaPath)).resolves.toBeUndefined();
   });
 });

--- a/packages/plugin-ios/src/ios/wda/wda-build.test.ts
+++ b/packages/plugin-ios/src/ios/wda/wda-build.test.ts
@@ -96,4 +96,32 @@ describe("WDAManager build path", () => {
 
     expect(existsSync(buildArgsLog)).toBe(false);
   });
+
+  it("targets a booted simulator instead of a hardcoded device name", async () => {
+    const manager = new WDAManager();
+    harness(manager).derivedDataRoot = derivedDataRoot;
+
+    await harness(manager).buildWDAIfNeeded(wdaPath);
+
+    const args = readFileSync(buildArgsLog, "utf8");
+    expect(args).toContain("id=UDID-BOOTED");
+    expect(args).not.toContain("iPhone 14");
+  });
+
+  it("reports that no simulator is available instead of failing obscurely", async () => {
+    writeFileSync(devicesJson, JSON.stringify({ devices: {} }));
+    const manager = new WDAManager();
+    harness(manager).derivedDataRoot = derivedDataRoot;
+
+    await expect(harness(manager).buildWDAIfNeeded(wdaPath)).rejects.toThrow(/no iOS simulator/i);
+  });
+
+  it("builds the simulator runner without code signing", async () => {
+    const manager = new WDAManager();
+    harness(manager).derivedDataRoot = derivedDataRoot;
+
+    await harness(manager).buildWDAIfNeeded(wdaPath);
+
+    expect(readFileSync(buildArgsLog, "utf8")).toContain("CODE_SIGNING_ALLOWED=NO");
+  });
 });

--- a/packages/plugin-ios/src/ios/wda/wda-build.test.ts
+++ b/packages/plugin-ios/src/ios/wda/wda-build.test.ts
@@ -1,0 +1,99 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { delimiter, join } from "node:path";
+
+import { WDAManager } from "./wda-manager.js";
+
+/**
+ * Build-path tests. Follows the fake-binary-on-PATH strategy from client.test.ts:
+ * real code runs, only `xcrun` / `xcodebuild` are shimmed, so nothing here mocks
+ * the module under test.
+ */
+
+interface BuildHarness {
+  derivedDataRoot: string;
+  buildTimeout: number;
+  buildWDAIfNeeded(wdaPath: string): Promise<void>;
+}
+
+function harness(manager: WDAManager): BuildHarness {
+  return manager as unknown as BuildHarness;
+}
+
+const DEVICES_JSON = JSON.stringify({
+  devices: {
+    "com.apple.CoreSimulator.SimRuntime.iOS-18-0": [
+      { udid: "UDID-BOOTED", name: "iPhone 16 Pro", state: "Booted", isAvailable: true },
+      { udid: "UDID-SHUTDOWN", name: "iPhone 16", state: "Shutdown", isAvailable: true },
+    ],
+  },
+});
+
+describe("WDAManager build path", () => {
+  let workDir: string;
+  let wdaPath: string;
+  let derivedDataRoot: string;
+  let buildArgsLog: string;
+  let devicesJson: string;
+  let listappsOut: string;
+  let savedPath: string | undefined;
+
+  beforeEach(() => {
+    workDir = mkdtempSync(join(tmpdir(), "cim-wda-build-"));
+    wdaPath = join(workDir, "wda");
+    derivedDataRoot = join(workDir, "DerivedData");
+    buildArgsLog = join(workDir, "xcodebuild-args");
+    devicesJson = join(workDir, "devices.json");
+    listappsOut = join(workDir, "listapps.txt");
+
+    mkdirSync(join(wdaPath, "WebDriverAgent.xcodeproj"), { recursive: true });
+    // appium-webdriveragent ships `build/` as its TypeScript output — always present,
+    // and unrelated to whether xcodebuild has ever run.
+    mkdirSync(join(wdaPath, "build"), { recursive: true });
+    mkdirSync(derivedDataRoot, { recursive: true });
+
+    const bin = join(workDir, "bin");
+    mkdirSync(bin, { recursive: true });
+    writeFileSync(join(bin, "xcodebuild"), `#!/bin/sh\necho "$@" > "${buildArgsLog}"\nexit 0\n`);
+    chmodSync(join(bin, "xcodebuild"), 0o755);
+    writeFileSync(devicesJson, DEVICES_JSON);
+    writeFileSync(listappsOut, "");
+    writeFileSync(
+      join(bin, "xcrun"),
+      `#!/bin/sh\ncase "$*" in\n  *listapps*) cat "${listappsOut}" ;;\n  *) cat "${devicesJson}" ;;\nesac\n`,
+    );
+    chmodSync(join(bin, "xcrun"), 0o755);
+
+    savedPath = process.env.PATH;
+    process.env.PATH = `${bin}${delimiter}${savedPath ?? ""}`;
+  });
+
+  afterEach(() => {
+    if (savedPath !== undefined) process.env.PATH = savedPath;
+    rmSync(workDir, { recursive: true, force: true });
+  });
+
+  it("builds when DerivedData holds no runner app, despite the npm build/ directory", async () => {
+    const manager = new WDAManager();
+    harness(manager).derivedDataRoot = derivedDataRoot;
+
+    await harness(manager).buildWDAIfNeeded(wdaPath);
+
+    expect(existsSync(buildArgsLog)).toBe(true);
+  });
+
+  it("skips the build when DerivedData already holds the runner app", async () => {
+    mkdirSync(
+      join(derivedDataRoot, "WebDriverAgent-abc123", "Build", "Products",
+           "Debug-iphonesimulator", "WebDriverAgentRunner-Runner.app"),
+      { recursive: true },
+    );
+    const manager = new WDAManager();
+    harness(manager).derivedDataRoot = derivedDataRoot;
+
+    await harness(manager).buildWDAIfNeeded(wdaPath);
+
+    expect(existsSync(buildArgsLog)).toBe(false);
+  });
+});

--- a/packages/plugin-ios/src/ios/wda/wda-build.ts
+++ b/packages/plugin-ios/src/ios/wda/wda-build.ts
@@ -1,0 +1,33 @@
+/**
+ * Filesystem probes for the WebDriverAgent build. No process spawning.
+ */
+
+import * as fs from "fs";
+import * as path from "path";
+
+const RUNNER_APP = "WebDriverAgentRunner-Runner.app";
+
+/**
+ * DerivedData carries the only reliable evidence that xcodebuild has produced a
+ * runner. The `build/` directory inside the appium-webdriveragent package does
+ * not: npm ships it as that package's TypeScript output, so it is always there.
+ */
+export function findRunnerApp(derivedDataRoot: string): string | undefined {
+  for (const entry of readdirOrEmpty(derivedDataRoot)) {
+    if (!entry.startsWith("WebDriverAgent-")) continue;
+    const products = path.join(derivedDataRoot, entry, "Build", "Products");
+    for (const config of readdirOrEmpty(products)) {
+      const app = path.join(products, config, RUNNER_APP);
+      if (fs.existsSync(app)) return app;
+    }
+  }
+  return undefined;
+}
+
+function readdirOrEmpty(dir: string): string[] {
+  try {
+    return fs.readdirSync(dir);
+  } catch {
+    return [];
+  }
+}

--- a/packages/plugin-ios/src/ios/wda/wda-build.ts
+++ b/packages/plugin-ios/src/ios/wda/wda-build.ts
@@ -5,6 +5,8 @@
 import * as fs from "fs";
 import * as path from "path";
 
+import type { IosDevice } from "../types.js";
+
 const RUNNER_APP = "WebDriverAgentRunner-Runner.app";
 
 /**
@@ -30,4 +32,13 @@ function readdirOrEmpty(dir: string): string[] {
   } catch {
     return [];
   }
+}
+
+/**
+ * Booted first: building against an already-running simulator skips a boot, and
+ * `iPhone 14` is not guaranteed to exist on machines with a newer Xcode.
+ */
+export function pickBuildSimulator(devices: IosDevice[]): IosDevice | undefined {
+  const usable = devices.filter((device) => /^(iPhone|iPad)/.test(device.name));
+  return usable.find((device) => device.state === "booted") ?? usable[0];
 }

--- a/packages/plugin-ios/src/ios/wda/wda-manager.ts
+++ b/packages/plugin-ios/src/ios/wda/wda-manager.ts
@@ -4,6 +4,7 @@ import * as path from "path";
 import * as os from "os";
 import { createServer } from "net";
 import { WDAClient } from "./wda-client.js";
+import { findRunnerApp } from "./wda-build.js";
 import type { WDAInstanceInfo } from "./wda-types.js";
 
 const DEVICE_WDA_PORT = 8100;
@@ -29,6 +30,7 @@ export class WDAManager {
   private readonly startupTimeout = 30_000;
   private readonly deviceStartupTimeout = 300_000;
   private readonly buildTimeout = 120_000;
+  private readonly derivedDataRoot = path.join(os.homedir(), "Library/Developer/Xcode/DerivedData");
   private disposed = false;
   private cleanupPromise?: Promise<void>;
 
@@ -151,7 +153,7 @@ export class WDAManager {
   }
 
   private async buildWDAIfNeeded(wdaPath: string): Promise<void> {
-    if (fs.existsSync(path.join(wdaPath, "build"))) return;
+    if (findRunnerApp(this.derivedDataRoot)) return;
     console.error("Building WebDriverAgent for first use...");
     try {
       execSync(

--- a/packages/plugin-ios/src/ios/wda/wda-manager.ts
+++ b/packages/plugin-ios/src/ios/wda/wda-manager.ts
@@ -176,7 +176,7 @@ export class WDAManager {
         "xcodebuild build-for-testing -project WebDriverAgent.xcodeproj " +
         `-scheme WebDriverAgentRunner -destination '${destination}' `
         + "CODE_SIGNING_ALLOWED=NO",
-        { cwd: wdaPath, timeout: this.buildTimeout, stdio: "pipe" },
+        { cwd: wdaPath, timeout: this.buildTimeout, stdio: "pipe", maxBuffer: 50 * 1024 * 1024 },
       );
     } catch (error) {
       const details = error as { stderr?: Buffer | string; stdout?: Buffer | string; message?: string };

--- a/packages/plugin-ios/src/ios/wda/wda-manager.ts
+++ b/packages/plugin-ios/src/ios/wda/wda-manager.ts
@@ -4,8 +4,11 @@ import * as path from "path";
 import * as os from "os";
 import { createServer } from "net";
 import { WDAClient } from "./wda-client.js";
-import { findRunnerApp } from "./wda-build.js";
+import { findRunnerApp, pickBuildSimulator } from "./wda-build.js";
+import { execSimctl } from "../simctl-exec.js";
+import { parseDevicesJson } from "../simctl-parsers.js";
 import type { WDAInstanceInfo } from "./wda-types.js";
+import type { IosDevice } from "../types.js";
 
 const DEVICE_WDA_PORT = 8100;
 const GO_IOS_BIN = process.env.GO_IOS_BIN ?? "ios";
@@ -152,13 +155,27 @@ export class WDAManager {
     );
   }
 
+  private resolveSimulatorDestination(devices: IosDevice[]): string {
+    const device = pickBuildSimulator(devices);
+    if (!device) {
+      throw new Error(
+        "No iOS simulator available to build WebDriverAgent against. "
+        + "Create one in Xcode (Window > Devices and Simulators).",
+      );
+    }
+    return `platform=iOS Simulator,id=${device.id}`;
+  }
+
   private async buildWDAIfNeeded(wdaPath: string): Promise<void> {
     if (findRunnerApp(this.derivedDataRoot)) return;
+    const devices = parseDevicesJson(execSimctl(["list", "devices", "-j"]));
+    const destination = this.resolveSimulatorDestination(devices);
     console.error("Building WebDriverAgent for first use...");
     try {
       execSync(
         "xcodebuild build-for-testing -project WebDriverAgent.xcodeproj " +
-        "-scheme WebDriverAgentRunner -destination 'platform=iOS Simulator,name=iPhone 14'",
+        `-scheme WebDriverAgentRunner -destination '${destination}' `
+        + "CODE_SIGNING_ALLOWED=NO",
         { cwd: wdaPath, timeout: this.buildTimeout, stdio: "pipe" },
       );
     } catch (error) {


### PR DESCRIPTION
Three independent defects on the simulator build path in `WDAManager`, each with its own
commit. They compound: the first prevents the build from ever running, which hides the
other two behind it.

### 1. The build was never triggered

`buildWDAIfNeeded` returned early whenever `<wdaPath>/build` existed. That directory is
the `appium-webdriveragent` package's own TypeScript output — npm always ships it, and it
carries no information about whether `xcodebuild` has run. Auto-build therefore never
fired, and `test-without-building` failed on clean DerivedData.

Now checks DerivedData for a real `WebDriverAgentRunner-Runner.app`.

### 2. `-destination` was pinned to `iPhone 14`

That simulator need not exist on a machine with a newer Xcode. Now picks a booted
iPhone/iPad, falls back to the first available, and raises a legible error when there is
none — previously a `TypeError` wrapped in "Failed to build WebDriverAgent". Resolution
reuses the existing `execSimctl` + `parseDevicesJson` rather than adding a second parser.
`CODE_SIGNING_ALLOWED=NO` keeps the simulator build from stalling on a signing prompt.

### 3. The build was killed once its output passed 1 MB

`execSync` defaults to a 1 MB `maxBuffer`. A cold `build-for-testing` writes just past
that, so Node SIGTERMs `xcodebuild` mid-build. The result surfaced as "Failed to build
WebDriverAgent" carrying truncated output that named no cause. Raised to the 50 MB already
used by `simctl-exec.ts`.

This one only appears once defect 1 is fixed and the build actually runs.

### Testing

New `wda-build.test.ts` (6 tests) follows the fake-binary-on-`PATH` strategy already used
in `client.test.ts`: `xcrun` and `xcodebuild` are shimmed in a temp dir, DerivedData is a
real temp tree, and the code under test runs unmocked.

Since `ci.yml` only triggers on `pull_request: [main]`, this PR gets no CI. Run locally on
the branch head:

```
npm run build      # ok
npx tsc --noEmit   # ok
npx vitest run     # 72 files / 1493 tests passed
```

Baseline on `release/v4.2.0` (`1072f43`) is 71 files / 1487 tests, so the delta is the six
added tests and no regressions. Each commit was verified green on its own.

### Verified on hardware

macOS, Xcode 26.6, a booted iPhone 17 Pro, no `iPhone 14` simulator present.

| state | `release/v4.2.0` | this branch |
|---|---|---|
| DerivedData holds the runner | skip, 0 ms — on the false `build/` signal | skip, 0 ms, on the DerivedData artifact |
| DerivedData clean | skip, 0 ms → `test-without-building` then fails | builds, then launches: 20.6 s to a live session |

Supporting measurements:

- `<wdaPath>/build` here contains `index.d.ts`, `index.js`, `lib` — the package's
  TypeScript output, confirming the signal carries no build information.
- Running the current `-destination 'platform=iOS Simulator,name=iPhone 14'` by hand
  spends 61 s before failing with `Unable to find a device matching`.
- With DerivedData removed, the same `execSync` call fails at `code=ENOBUFS`,
  `signal=SIGTERM` after 1.6 s with 1,049,270 bytes captured; at `maxBuffer: 50 MB` it
  succeeds in 16.7 s.
- End to end from an empty DerivedData: the build runs, the runner launches on the
  requested simulator, and `getUiHierarchy` returns a live tree — 20.6 s in total.
- From a genuinely cold machine — DerivedData emptied entirely, Xcode's module cache with
  it, and `com.facebook.WebDriverAgentRunner.xctrunner` uninstalled from the simulator —
  the same call completes in **~40 s**, well inside the existing 120 s `buildTimeout`.
  DerivedData comes back at 147 MB with the runner rebuilt. The timeout is left alone.

Pure helpers live in a new `wda/wda-build.ts`, following the existing `wda-errors.ts` /
`simctl-parsers.ts` split.
