### PR TITLE
fix(ios): revalidate the WDA session on every ensureWDA call

### DIFF
--- a/packages/plugin-ios/src/ios/client-session.test.ts
+++ b/packages/plugin-ios/src/ios/client-session.test.ts
@@ -1,0 +1,65 @@
+import { EventEmitter } from "node:events";
+import type { ChildProcess } from "node:child_process";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { IosClient } from "./client.js";
+import { WDAManager } from "./wda/wda-manager.js";
+import type { WDAClient } from "./wda/wda-client.js";
+
+interface ClientHarness {
+  wdaClient?: WDAClient & { sessionId: string | null };
+  ensureWDA(deviceIdOverride?: string): Promise<WDAClient>;
+}
+
+interface ManagerHarness {
+  publishInstance(deviceId: string, port: number, child: ChildProcess): unknown;
+}
+
+function fakeChild(pid: number): ChildProcess {
+  const child = new EventEmitter() as unknown as ChildProcess;
+  Object.assign(child, { pid, exitCode: null, signalCode: null, kill: vi.fn(() => true) });
+  return child;
+}
+
+function jsonResponse(body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("IosClient session lifetime", () => {
+  it("recreates a session WDA has dropped instead of reusing the dead one", async () => {
+    const manager = new WDAManager();
+    (manager as unknown as ManagerHarness).publishInstance("device-a", 8_181, fakeChild(20_001));
+    const client = new IosClient("device-a", manager);
+    const harness = client as unknown as ClientHarness;
+
+    let created = 0;
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input, init) => {
+      const url = String(input);
+      const method = (init as RequestInit | undefined)?.method ?? "GET";
+      if (method === "POST" && url.endsWith("/session")) {
+        created += 1;
+        return jsonResponse({ sessionId: `session-${created}` });
+      }
+      // WDA has evicted the session it handed out earlier.
+      if (method === "GET" && url.includes("/session/")) {
+        return new Response("invalid session id", { status: 404 });
+      }
+      return jsonResponse({ value: {} });
+    });
+
+    await harness.ensureWDA();
+    expect(harness.wdaClient?.sessionId).toBe("session-1");
+
+    await harness.ensureWDA();
+
+    expect(harness.wdaClient?.sessionId).toBe("session-2");
+    await manager.cleanup();
+  });
+});

--- a/packages/plugin-ios/src/ios/client.ts
+++ b/packages/plugin-ios/src/ios/client.ts
@@ -84,12 +84,13 @@ export class IosClient {
       );
     }
 
-    if (!this.wdaClient || !this.wdaManager.isClientActive(effectiveId, this.wdaClient)) {
-      this.wdaClient = await this.wdaManager.ensureWDAReady(
-        effectiveId,
-        this.isSimulatorDevice(effectiveId)
-      );
-    }
+    // isClientActive only proves the runner process is alive; WDA can still have
+    // dropped the session (single-session eviction, idle GC). ensureWDAReady
+    // revalidates it and recreates on 404, so a dead session self-heals.
+    this.wdaClient = await this.wdaManager.ensureWDAReady(
+      effectiveId,
+      this.isSimulatorDevice(effectiveId)
+    );
     return this.wdaClient;
   }
 


### PR DESCRIPTION
A cached `WDAClient` can hold a session WebDriverAgent has already dropped, and nothing
brings it back.

### The defect

`ensureWDA` skipped `ensureWDAReady` whenever `isClientActive` returned true:

```ts
if (!this.wdaClient || !this.wdaManager.isClientActive(effectiveId, this.wdaClient)) {
  this.wdaClient = await this.wdaManager.ensureWDAReady(...);
}
```

`isClientActive` proves two things — the runner child process is alive, and the manager
still owns this client object. It says nothing about whether WDA still holds the session
it handed out. WebDriverAgent serves one session at a time: the moment anything else
creates one, the previous id is evicted.

So after an eviction the guard keeps returning the cached client, the dead id is reused,
and every later call fails with `invalid session id` — for the life of the process, since
the same guard keeps skipping the revalidation that would fix it.

The recovery machinery already exists: `ensureWDAReady` calls `ensureSession`, which
re-checks with `GET /session/{id}` and recreates on failure. The guard was bypassing it.

### The fix

Always route through `ensureWDAReady`. One line of control flow.

Cost on the warm path: one `GET /session/{id}` per iOS call against localhost. That is the
trade — a few milliseconds against a session that otherwise stays broken until the server
restarts.

`isClientActive` keeps its other caller inside `ensureWDAReady`, so it is not orphaned.

### Testing

One test in a new `client-session.test.ts`, running the real `IosClient`, `WDAManager` and
`WDAClient` with only `fetch` stubbed: WDA 404s the first session, and the assertion is on
the client's session id moving from the first to the second — the behaviour, not a call
count.

```
npm run build      # ok
npx tsc --noEmit   # ok
npx vitest run     # 72 files / 1488 tests passed
```

Baseline on `release/v4.2.0` (`1072f43`) is 71 files / 1487 tests: one added test, no
regressions.

### Verified against a live WebDriverAgent

macOS, Xcode 26.6, WDA serving on :8100.

Eviction is real, and the error is the one quoted above:

```
session 1 created:  256C038F-…      GET /session/256C038F-… -> 200
session 2 created:  C7B65EF1-…      (a different id — the first is gone)
GET /session/256C038F-…             -> 404
{"value":{"error":"invalid session id","message":"Session does not exist"}}
```

Same scenario driven through the built `dist` — first call, a foreign session created
against the same WDA, then a second call:

| step | `release/v4.2.0` | this branch |
|---|---|---|
| first `getUiHierarchy` | ok, 7306 chars | ok, 7306 chars |
| a foreign session evicts ours | — | — |
| second `getUiHierarchy` | **fails, 404** | **recovers, 7306 chars** |

Two MCP server processes against one simulator reach this state on their own: whichever
creates the second session leaves the other permanently broken.
