### PR TITLE
fix(wda): probe the wildcard address when reserving a port

### DIFF
--- a/packages/plugin-ios/src/ios/wda/wda-manager.ts
+++ b/packages/plugin-ios/src/ios/wda/wda-manager.ts
@@ -366,7 +366,10 @@ export class WDAManager {
           RESERVED_PORTS.add(port);
           server.close(() => resolve(true));
         });
-        server.listen(port, "127.0.0.1");
+        // Probe the wildcard address: WebDriverAgent binds 0.0.0.0, and a probe
+        // pinned to 127.0.0.1 does not collide with it, so a port another
+        // process already serves would be reported free.
+        server.listen(port);
       });
       if (available) return port;
     }

--- a/packages/plugin-ios/src/ios/wda/wda-port.test.ts
+++ b/packages/plugin-ios/src/ios/wda/wda-port.test.ts
@@ -1,0 +1,45 @@
+import { createServer, type Server } from "node:net";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { WDAManager } from "./wda-manager.js";
+
+interface PortHarness {
+  reservePort(): Promise<number>;
+}
+
+/** Bind the way WebDriverAgent does — the wildcard address, not a single interface. */
+function bind(port: number): Promise<Server | undefined> {
+  return new Promise((resolve) => {
+    const server = createServer();
+    server.once("error", () => resolve(undefined));
+    server.once("listening", () => resolve(server));
+    server.listen(port);
+  });
+}
+
+function close(server: Server): Promise<void> {
+  return new Promise((resolve) => server.close(() => resolve()));
+}
+
+const opened: Server[] = [];
+
+afterEach(async () => {
+  await Promise.all(opened.splice(0).map(close));
+});
+
+describe("WDAManager port reservation", () => {
+  it("does not hand out a port another process already serves", async () => {
+    // Establish the condition if it is not already there: something serving 8100
+    // on the wildcard address, exactly as a WebDriverAgent left by another process.
+    const squatter = await bind(8_100);
+    if (squatter) opened.push(squatter);
+
+    const manager = new WDAManager();
+    const port = await (manager as unknown as PortHarness).reservePort();
+    const held = await bind(port);
+    if (held) opened.push(held);
+
+    expect(held).toBeDefined();
+    await manager.cleanup();
+  });
+});


### PR DESCRIPTION
`reservePort` can hand out a port another process is already serving, and the consequence
is silent: commands go to a different simulator than the one that was asked for.

### The defect

```ts
server.listen(port, "127.0.0.1");
```

WebDriverAgent binds the wildcard address. A probe pinned to `127.0.0.1` does not collide
with a listener on `0.0.0.0` — the kernel grants both — so the probe succeeds and the port
is reported free.

What follows:

1. `reservePort` returns a port a foreign WDA is serving.
2. `launchSimulator` spawns a second runner against it.
3. `waitForHealth` polls `/status` on that port and passes **immediately** — it is talking
   to the other process's WDA, not to the runner just spawned.
4. The client creates a session there. WDA drives the device it runs on, so the session
   lands on whatever simulator the foreign WDA is attached to.

No error is raised at any step. The caller asks for one simulator and automates another.

### The fix

Probe the same address WDA serves on — drop the host argument. One token.

This does not widen exposure: the probe socket is opened and closed within the same call
and never carries traffic, and WDA itself already listens on `0.0.0.0`.

### Testing

One test in a new `wda-port.test.ts`. It establishes the condition — a listener on 8100
bound the way WDA binds — then asserts the invariant that matters: a port handed out by
`reservePort` must actually be bindable. It lives in its own file because `RESERVED_PORTS`
is module state, and sharing it across the ownership tests would make the result depend on
test order.

```
npm run build      # ok
npx tsc --noEmit   # ok
npx vitest run     # 72 files / 1488 tests passed
```

Baseline on `release/v4.2.0` (`1072f43`) is 71 files / 1487 tests: one added test, no
regressions.

### Verified on hardware

macOS, Xcode 26.6, two booted simulators, a WebDriverAgent from an unrelated process
serving 8100 and attached to `BACCF65D…` (iPhone 17 Pro Max).

Port arithmetic:

| | `release/v4.2.0` | this branch |
|---|---|---|
| `reservePort()` twice | `8100, 8101` — 8100 is occupied | `8101, 8102` — 8100 skipped |

The consequence, driven through the built `dist` with `getUiHierarchy` against
`35504A77…` (iPhone 17 Pro):

| | `release/v4.2.0` | this branch |
|---|---|---|
| port used | 8100 — the foreign WDA | 8101 — its own |
| device actually served | `BACCF65D…` — **not the one requested** | `35504A77…` — the one requested |
| runner launched on | none of its own | `35504A77…` |

A leftover WDA is not exotic: a crashed MCP process, a second editor session, or a manual
`xcodebuild test-without-building` all leave one behind.
