### PR TITLE
fix(ios): read the UI tree from a source that carries geometry

### DIFF
--- a/packages/plugin-ios/src/ios/client.ts
+++ b/packages/plugin-ios/src/ios/client.ts
@@ -355,7 +355,7 @@ export class IosClient {
   async getUiHierarchy(deviceIdOverride?: string): Promise<string> {
     try {
       const wdaClient = await this.ensureWDA(deviceIdOverride);
-      const tree = await wdaClient.getAccessibleSource();
+      const tree = await wdaClient.getSourceTree();
       return JSON.stringify(tree, null, 2);
     } catch (error: unknown) {
       throw wdaRequiredError("WebDriverAgent", error);

--- a/packages/plugin-ios/src/ios/wda/wda-client.test.ts
+++ b/packages/plugin-ios/src/ios/wda/wda-client.test.ts
@@ -138,3 +138,37 @@ describe("WDAClient — degraded envelope must throw, not leak the wrapper", () 
     );
   });
 });
+
+/**
+ * The UI tree is only useful if it carries geometry: every downstream consumer
+ * (iosTreeToUiElements -> ui(tree), hints, flow) drops nodes without a rect.
+ * Real WDA answers /wda/accessibleSource without rects at all, and
+ * /source?format=json with them.
+ */
+describe("WDAClient — the UI tree must carry element geometry", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it("reads a source that carries rects, not the geometry-free accessibility tree", async () => {
+    const client = new WDAClient(8100);
+    (client as unknown as { sessionId: string | null }).sessionId = "TEST";
+    vi.stubGlobal("fetch", vi.fn(async (url: unknown) =>
+      String(url).includes("/wda/accessibleSource")
+        ? jsonResponse({ status: 0, value: { type: "XCUIElementTypeApplication", name: "App", children: [] } })
+        : jsonResponse({
+            status: 0,
+            value: {
+              type: "XCUIElementTypeApplication",
+              rect: { x: 0, y: 0, width: 390, height: 844 },
+              children: [],
+            },
+          }),
+    ));
+
+    const tree = await client.getAccessibleSource();
+
+    expect((tree as { rect?: unknown }).rect).toBeDefined();
+  });
+});

--- a/packages/plugin-ios/src/ios/wda/wda-client.test.ts
+++ b/packages/plugin-ios/src/ios/wda/wda-client.test.ts
@@ -55,11 +55,11 @@ describe("unwrapWdaValue — WDA envelope validation", () => {
 
   it("error message names the context and the degradation", () => {
     try {
-      unwrapWdaValue({ status: 0, value: null }, "accessibleSource");
+      unwrapWdaValue({ status: 0, value: null }, "source");
       expect.unreachable("should have thrown");
     } catch (err: any) {
       expect(err).toBeInstanceOf(WdaTreeError);
-      expect(err.message).toContain("accessibleSource");
+      expect(err.message).toContain("source");
       expect(err.message).toContain("WebDriverAgent session");
     }
   });
@@ -82,23 +82,23 @@ describe("WDAClient — degraded envelope must throw, not leak the wrapper", () 
     vi.restoreAllMocks();
   });
 
-  it("getAccessibleSource throws WdaTreeError on {value:null}", async () => {
+  it("getSourceTree throws WdaTreeError on {value:null}", async () => {
     fetchMock.mockResolvedValueOnce(
       jsonResponse({ status: 0, value: null, sessionId: "TEST" }),
     );
-    await expect(client.getAccessibleSource()).rejects.toBeInstanceOf(
+    await expect(client.getSourceTree()).rejects.toBeInstanceOf(
       WdaTreeError,
     );
   });
 
-  it("getAccessibleSource returns the tree on a healthy envelope", async () => {
+  it("getSourceTree returns the tree on a healthy envelope", async () => {
     const tree = {
       type: "XCUIElementTypeApplication",
       rect: { x: 0, y: 0, width: 390, height: 844 },
       children: [],
     };
     fetchMock.mockResolvedValueOnce(jsonResponse({ status: 0, value: tree }));
-    await expect(client.getAccessibleSource()).resolves.toEqual(tree);
+    await expect(client.getSourceTree()).resolves.toEqual(tree);
   });
 
   it("findElement throws WdaTreeError on {value:null} instead of returning the envelope", async () => {
@@ -167,7 +167,7 @@ describe("WDAClient — the UI tree must carry element geometry", () => {
           }),
     ));
 
-    const tree = await client.getAccessibleSource();
+    const tree = await client.getSourceTree();
 
     expect((tree as { rect?: unknown }).rect).toBeDefined();
   });

--- a/packages/plugin-ios/src/ios/wda/wda-client.ts
+++ b/packages/plugin-ios/src/ios/wda/wda-client.ts
@@ -74,9 +74,11 @@ export class WDAClient {
       throw new Error("No active WDA session");
     }
 
+    // Page source, not /wda/accessibleSource: the accessibility tree carries no
+    // rects, and every consumer downstream drops nodes that have no geometry.
     const response = await this.request(
       "GET",
-      `/session/${this.sessionId}/wda/accessibleSource`
+      `/session/${this.sessionId}/source?format=json`
     );
     // Trust boundary: a degraded session returns 200 with {value:null}. Reject
     // it here instead of casting the envelope to a tree (which yields an empty

--- a/packages/plugin-ios/src/ios/wda/wda-client.ts
+++ b/packages/plugin-ios/src/ios/wda/wda-client.ts
@@ -69,7 +69,7 @@ export class WDAClient {
     }
   }
 
-  async getAccessibleSource(): Promise<UITreeNode> {
+  async getSourceTree(): Promise<UITreeNode> {
     if (!this.sessionId) {
       throw new Error("No active WDA session");
     }
@@ -83,7 +83,7 @@ export class WDAClient {
     // Trust boundary: a degraded session returns 200 with {value:null}. Reject
     // it here instead of casting the envelope to a tree (which yields an empty
     // parse and poisons downstream caches). See WdaTreeError.
-    return unwrapWdaValue<UITreeNode>(response, "accessibleSource");
+    return unwrapWdaValue<UITreeNode>(response, "source");
   }
 
   async findElement(


### PR DESCRIPTION
`ui(action:"tree")` returns "No UI elements found" on iOS for every screen, and the hints
after an input action report "No UI elements detected." The tree itself is fine — the
request asks for a variant of it that carries no geometry.

### The defect

`WDAClient.getAccessibleSource` reads `/session/{id}/wda/accessibleSource`. That endpoint
returns an accessibility tree with **no `rect` on any node**. `walkWdaNode`
(`src/tools/context/ios-helpers.ts`) emits a node only when `rect.width > 0 &&
rect.height > 0`, so every node falls through to the child recursion and the element list
comes back empty.

Measured on one live tree, in one process:

```
/wda/accessibleSource       40297 chars,   0 "rect"  ->   0 elements
/source?format=json        321734 chars, 168 "rect"  -> 166 elements
/source?format=description  16801 chars,   0 "rect"
```

The converter is not at fault: `WdaNode` describes `rect / type / label / value / name /
identifier / enabled / selected / children`, which is exactly the page-source shape. It was
written against `/source`; the client was never switched to it.

Everything fed by the converter was affected:

```
src/tools/ui/tree.ts:99                ui(tree)
src/tools/helpers/get-elements.ts:38   getUiElements -> flow, hints
src/tools/context/hints.ts:106,134     hints after an input action
```

`ui(find)` and tap-by-label were not: they go through `iosClient.findElements`, WDA's own
element search, which returns rects regardless of this path.

### Why it appeared

Until recently the iOS branch of `ui(tree)` used its own formatter:

```ts
const formatted = ctx.formatIOSUITree(tree);
return textResult(formatted);
```

That formatter walks the tree textually and needs no geometry, so the geometry-free
endpoint was adequate. The current code routes iOS through the shared `UiElement[]` path
instead — which is the right call, since it is what makes `compact` / `format` / hints work
on iOS — but the data source stayed behind. `formatIOSUITree` is still exported and still
works (3693 chars of hierarchy on the same tree that yields 0 elements); nothing calls it.

Two notes for context rather than argument:

- The "No UI elements detected." symptom was chased once before, in the `{value:null}`
  envelope fix that `wda-client.test.ts` documents. That fix was correct; this is a second,
  independent cause of the same message.
- The existing fixture in `wda-client.test.ts` builds its healthy-envelope tree *with* a
  `rect`, which is why the unit tests never caught the mismatch. This PR adds a test that
  distinguishes the two endpoints instead of assuming them equivalent.

### The fix

Read `/source?format=json` and rename the method to `getSourceTree`, since it no longer
reads `accessibleSource`. `WDAClient` is internal to the package — not exported from its
index — and the method had one caller.

### Cost

The page source is larger and slower. Measured on a booted iPhone 17 Pro, three screens,
best–worst of three runs each:

| screen | `/wda/accessibleSource` | `/source?format=json` | size |
|---|---|---|---|
| home screen | 7 913 chars, 599–667 ms | 221 285 chars, 1174–1181 ms | ×28 |
| Settings root | 40 297 chars, 405–542 ms | 321 734 chars, 604–630 ms | ×8 |
| Safari, long article | 5 379 chars, 570–629 ms | 190 205 chars, 663–732 ms | ×35 |

Payload grows 8–35×, latency 1.2–1.9×. `excludedAttributes` is accepted but ignored by
this WDA build, so the payload cannot be trimmed that way. The trade is a slower call
against a call whose result cannot drive interaction at all — the geometry-free tree has no
coordinates to tap.

### Testing

One test added to `wda-client.test.ts`: a stubbed WDA answers the two endpoints the way the
real one does — accessibility tree without rects, page source with them — and the assertion
is that the tree the client returns carries geometry.

```
npm run build      # ok
npx tsc --noEmit   # ok
npx vitest run     # 71 files / 1488 tests passed
```

Baseline on `release/v4.2.0` (`1072f43`) is 71 files / 1487 tests.

### Verified on hardware

macOS, Xcode 26.6, booted iPhone 17 Pro. Through the built `dist`, same screen before and
after: **0 elements → 166 elements**, with coordinates —

```
<Application> " " @ (201,437)
<Window> "SBSwitcherWindow:Main" @ (201,437)
<StaticText> "12:44" @ (74,25)
```

Through the MCP server itself, same screen, `ui(action:"tree", format:"semantic")`:

```
Actions: [88] "Return to Settings" (40,40) | [148] "Settings" (127,567) | [149] "Continue" (275,567)
Text: " ", "SBSwitcherWindow:Main", "AppSwitcherContentView", "Safari", "12:49" (+14)
```

And the hints after a tap, which had reported "No UI elements detected." on every action:

```
Screen changed (new activity or major UI update)
New:  "Settings", "Settings", "Settings", CollectionView, "AdditionalDimmingOverlay"
Gone: " ", ScrollView, "Safari", ScrollView, StatusBar
Elements: 166 -> 166
Suggested: tap "Apple Account, ...", "General", "Accessibility"
```

That covers both halves of what issue #60 described — `compact` / `format` reaching iOS, and
hints carrying content.

`ui(action:"find")` and `input(action:"tap", label:...)` were already working and are
untouched: they go through `iosClient.findElements`, WDA's own element search, which
returns rects independently of this path.
