### PR TITLE
fix(ios): scale screenshot coordinates into points, not device pixels

### DIFF
--- a/packages/plugin-ios/src/ios-adapter.ts
+++ b/packages/plugin-ios/src/ios-adapter.ts
@@ -158,6 +158,10 @@ export class IosAdapter
 
   // ============ UI ============
 
+  getScreenPointSize(deviceId?: string): Promise<{ width: number; height: number }> {
+    return this.clientFor(deviceId).getScreenPointSize(deviceId);
+  }
+
   async getUiHierarchy(deviceId?: string): Promise<string> {
     return this.clientFor(deviceId).getUiHierarchy(deviceId);
   }

--- a/packages/plugin-ios/src/ios/client.ts
+++ b/packages/plugin-ios/src/ios/client.ts
@@ -35,6 +35,7 @@ export class IosClient {
   private readonly wdaManager: WDAManager;
   private readonly ownsWdaManager: boolean;
   private wdaClient?: WDAClient;
+  private screenPointSize?: { width: number; height: number };
 
   constructor(deviceId?: string, wdaManager?: WDAManager) {
     this.wdaManager = wdaManager ?? new WDAManager();
@@ -213,6 +214,18 @@ export class IosClient {
   /**
    * Tap at coordinates
    */
+  /**
+   * Screen size in points — the space WDA's coordinate APIs work in. Screenshots
+   * are captured in device pixels, so callers scaling from one need both.
+   */
+  async getScreenPointSize(deviceIdOverride?: string): Promise<{ width: number; height: number }> {
+    if (!this.screenPointSize) {
+      const wdaClient = await this.ensureWDA(deviceIdOverride);
+      this.screenPointSize = await wdaClient.getWindowSize();
+    }
+    return this.screenPointSize;
+  }
+
   async tap(x: number, y: number, deviceIdOverride?: string): Promise<void> {
     try {
       const wdaClient = await this.ensureWDA(deviceIdOverride);

--- a/src/adapters/contracts.ts
+++ b/src/adapters/contracts.ts
@@ -57,6 +57,8 @@ export type RawLaunchOptionsLike = Record<string, unknown>;
 
 export interface IosClientLike {
   openUrl(url: string, deviceId?: string): void | Promise<void>;
+  /** Screen size in points — the space WDA's coordinate APIs work in. */
+  getScreenPointSize?(deviceId?: string): Promise<{ width: number; height: number }>;
   cleanup(): void | Promise<void>;
   [key: string]: any;
 }

--- a/src/tools/context.ts
+++ b/src/tools/context.ts
@@ -66,7 +66,7 @@ export interface ToolContext {
   setCachedElements: (platform: string, elements: UiElement[]) => void;
   lastScreenshotMap: Map<string, Buffer>;
   lastUiTreeMap: Map<string, { text: string; timestamp: number }>;
-  screenshotScaleMap: Map<string, { scaleX: number; scaleY: number }>;
+  screenshotScaleMap: Map<string, { scaleX: number; scaleY: number; originalWidth?: number; originalHeight?: number }>;
   generateActionHints: (platform?: string) => Promise<string>;
   getElementsForPlatform: (plat: string) => Promise<UiElement[]>;
   iosTreeToUiElements: (tree: any) => UiElement[];

--- a/src/tools/flow/common.ts
+++ b/src/tools/flow/common.ts
@@ -141,7 +141,7 @@ export async function turboFastTrack(
   if (FAST_TRACK_TAP.has(action)
       && typeof args.x === "number" && typeof args.y === "number"
       && !args.text && !args.resourceId && !args.index && !args.label) {
-    const scaled = applyScale(args.x as number, args.y as number, platform, ctx);
+    const scaled = await applyScale(args.x as number, args.y as number, platform, ctx);
     shellCmd = `input tap ${scaled.x} ${scaled.y}`;
     message = `Tapped at (${scaled.x}, ${scaled.y})`;
   }

--- a/src/tools/helpers/resolve-element.test.ts
+++ b/src/tools/helpers/resolve-element.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from "vitest";
-import { resolveElementCoordinates } from "./resolve-element.js";
+import { resolveElementCoordinates, applyScale } from "./resolve-element.js";
 import type { ToolContext } from "../context.js";
 import { ElementNotFoundError } from "../../errors.js";
 
@@ -311,5 +311,41 @@ describe("resolveElementCoordinates — no coordinates", () => {
     const ctx = makeCtx();
     const result = await resolveElementCoordinates({ action: "tap", platform: "android" }, ctx, "android");
     expect(result).toBeNull();
+  });
+});
+
+/**
+ * Screenshots are captured at device pixels; iOS taps go to WebDriverAgent, which
+ * takes points. A scale that stops at pixels sends the tap 2-3x past its target.
+ */
+describe("applyScale — iOS taps land in the point space WDA expects", () => {
+  it("carries screenshot coordinates into points, not device pixels", async () => {
+    const ctx = makeCtx({
+      getIosClient: () => ({ getScreenPointSize: async () => ({ width: 402, height: 874 }) }) as any,
+    });
+    (ctx.deviceManager as any).getCurrentPlatform = () => "ios";
+    // iPhone 17 Pro: 1206x2622 px = 402x874 pt, screenshot compressed to 442x960.
+    ctx.screenshotScaleMap.set("ios", {
+      scaleX: 1206 / 442,
+      scaleY: 2622 / 960,
+      originalWidth: 1206,
+      originalHeight: 2622,
+    } as any);
+
+    const { x } = await applyScale(353, 92, "ios", ctx);
+
+    // 353 of 442 across a 402-point-wide screen is the gear icon at 321.
+    expect(x).toBe(321);
+  });
+
+  it("leaves Android alone — its taps are already in device pixels", async () => {
+    const ctx = makeCtx();
+    ctx.screenshotScaleMap.set("android", {
+      scaleX: 2, scaleY: 2, originalWidth: 1080, originalHeight: 2400,
+    } as any);
+
+    const { x, y } = await applyScale(100, 200, "android", ctx);
+
+    expect({ x, y }).toEqual({ x: 200, y: 400 });
   });
 });

--- a/src/tools/helpers/resolve-element.ts
+++ b/src/tools/helpers/resolve-element.ts
@@ -28,19 +28,38 @@ export interface ResolvedCoordinates {
 /**
  * Apply screenshot scale to raw coordinates from Claude (image space -> device space).
  */
-export function applyScale(
+export async function applyScale(
   x: number,
   y: number,
   platform: string | undefined,
   ctx: ToolContext,
-): { x: number; y: number } {
+): Promise<{ x: number; y: number }> {
   const key = platform ?? ctx.deviceManager.getCurrentPlatform() ?? "android";
   const scale = ctx.screenshotScaleMap.get(key);
   if (!scale || (scale.scaleX === 1 && scale.scaleY === 1)) return { x, y };
-  return {
-    x: Math.round(x * scale.scaleX),
-    y: Math.round(y * scale.scaleY),
-  };
+
+  let { scaleX, scaleY } = scale;
+  if (key === "ios") {
+    // Screenshots are measured in device pixels; WDA's coordinate APIs take
+    // points. Without this the tap lands scale-factor times past its target.
+    const points = await iosPointSize(ctx);
+    if (points && scale.originalWidth && scale.originalHeight) {
+      scaleX /= scale.originalWidth / points.width;
+      scaleY /= scale.originalHeight / points.height;
+    }
+  }
+
+  return { x: Math.round(x * scaleX), y: Math.round(y * scaleY) };
+}
+
+async function iosPointSize(
+  ctx: ToolContext,
+): Promise<{ width: number; height: number } | undefined> {
+  try {
+    return await ctx.deviceManager.getIosClient().getScreenPointSize?.();
+  } catch {
+    return undefined;
+  }
 }
 
 /**

--- a/src/tools/interaction-tools.ts
+++ b/src/tools/interaction-tools.ts
@@ -60,7 +60,7 @@ export const interactionTools: ToolDefinition[] = [
       let { x, y } = resolved;
 
       if (resolved.fromRawArgs) {
-        ({ x, y } = applyScale(x, y, currentPlatform ?? undefined, ctx));
+        ({ x, y } = await applyScale(x, y, currentPlatform ?? undefined, ctx));
       }
 
       await ctx.deviceManager.tap(x, y, platform, args.targetPid, deviceId);
@@ -107,7 +107,7 @@ export const interactionTools: ToolDefinition[] = [
       let { x, y } = resolved;
 
       if (resolved.fromRawArgs) {
-        ({ x, y } = applyScale(x, y, currentPlatform ?? undefined, ctx));
+        ({ x, y } = await applyScale(x, y, currentPlatform ?? undefined, ctx));
       }
 
       await ctx.deviceManager.doubleTap(x, y, interval, platform, deviceId);
@@ -165,7 +165,7 @@ export const interactionTools: ToolDefinition[] = [
       let { x, y } = resolved;
 
       if (resolved.fromRawArgs) {
-        ({ x, y } = applyScale(x, y, currentPlatform ?? undefined, ctx));
+        ({ x, y } = await applyScale(x, y, currentPlatform ?? undefined, ctx));
       }
 
       await ctx.deviceManager.longPress(x, y, duration, platform, deviceId);
@@ -214,8 +214,8 @@ export const interactionTools: ToolDefinition[] = [
       if (x1 !== undefined && y1 !== undefined &&
           x2 !== undefined && y2 !== undefined) {
         const duration = args.duration;
-        const p1 = applyScale(x1, y1, currentPlatform ?? undefined, ctx);
-        const p2 = applyScale(x2, y2, currentPlatform ?? undefined, ctx);
+        const p1 = await applyScale(x1, y1, currentPlatform ?? undefined, ctx);
+        const p2 = await applyScale(x2, y2, currentPlatform ?? undefined, ctx);
         await ctx.deviceManager.swipe(p1.x, p1.y, p2.x, p2.y, duration, platform, deviceId);
         ctx.invalidateUiTreeCache(currentPlatform ?? undefined);
         let result = `Swiped from (${p1.x}, ${p1.y}) to (${p2.x}, ${p2.y})`;

--- a/src/tools/screenshot-tools.ts
+++ b/src/tools/screenshot-tools.ts
@@ -203,7 +203,11 @@ export const screenshotTools: ToolDefinition[] = [
       const scaled = scaleX !== 1 || scaleY !== 1;
 
       // Store scale so interaction tools can auto-correct coordinates
-      ctx.screenshotScaleMap.set(currentPlatform, { scaleX, scaleY });
+      ctx.screenshotScaleMap.set(currentPlatform, {
+        scaleX, scaleY,
+        originalWidth: result.originalWidth,
+        originalHeight: result.originalHeight,
+      });
 
       return {
         image: { data: result.data, mimeType: result.mimeType },


### PR DESCRIPTION
After any `screen(capture)`, a coordinate tap on iOS lands three times past its target and
reports success.

### The defect

`screenshot-tools.ts` records how much the screenshot was compressed:

```ts
const scaleX = result.originalWidth / result.width;   // 1206 / 442 = 2.73
```

`originalWidth` is the width of the raw PNG — device **pixels**. `applyScale` multiplies raw
tap coordinates by that factor, so a tap read off the screenshot arrives in pixel space.
WebDriverAgent's coordinate APIs take **points**. On this device 1206x2622 px is 402x874 pt,
so every such tap is off by the display scale — exactly 3.

Nothing reports it. The tool answers with the coordinates it used, the screen does not
change, and the caller is left guessing.

Observed on a booted iPhone 17 Pro driving a real app:

```
screen(capture, preset:"medium")  ->  Screenshot: 442x960 (device: 1206x2622)
input(tap, x:353, y:92)           ->  "Tapped at (963, 251)"   nothing happens
input(tap, x:118, y:31)           ->  "Tapped at (322, 85)"    hits the target
```

963 / 322 = 2.99. The only way to hit was to divide by 3 by hand.

Android is not affected: its taps are in device pixels, which is what the scale already
produces.

The path runs through three files:

```
src/tools/screenshot-tools.ts:201     scaleX = originalWidth / width   (pixels)
src/tools/helpers/resolve-element.ts  applyScale multiplies raw x/y by it
src/tools/interaction-tools.ts:63     applies it to the tap
```

The behaviour the tool documents (`interaction-tools.ts:14`, from #34) is the right one:

> COORDINATE SPACE: raw x/y are interpreted in the **last captured screenshot's pixel space**
> and auto-scaled to device coordinates before dispatch.

iOS just never reached it. "Device coordinates" for WebDriverAgent are points; the scale
stopped at device pixels. This PR makes the code do what that description already promises.

### Three coordinate spaces, two of which look alike

```
ui(tree), ui(find)   points          402 x 874
screen(capture)      compressed px   442 x 960
input(tap) raw x/y   scaled to px    1206 x 2622
```

A tap using coordinates from `ui(tree)` misses for the same reason as one using coordinates
from the screenshot: both are multiplied into pixel space.

### The fix

`applyScale` becomes async and, for iOS, divides by the device's pixels-per-point before
rounding. The point size comes from WDA's window size, fetched once per client and cached —
measured at 381 ms cold, 1 ms warm. The scale map now also records the original pixel
dimensions, which is what the divisor is computed against.

The correction happens at tap time rather than at capture time on purpose: `screen(capture)`
runs through simctl and needs no WebDriverAgent today, and making a screenshot wait on a WDA
launch would be a poor trade. Every tap already has a session.

The six call sites that scale raw coordinates — tap, double tap, long press, both ends of a
swipe, and the flow runner — gain an `await`. Android takes the same path and comes out
unchanged, its divisor being absent.

### What was already correct

Swipe was exercised on the device too: `input(swipe, x1:221, y1:700, x2:221, y2:250)` reports
`Swiped from (201, 637) to (201, 228)` — the same conversion — and the log view under it
actually scrolls. Long press takes the same helper and the same correction, but was not
exercised; worth a glance during review.

`input(tap, label:…)` and `ui(find)` resolve an element through `iosClient.findElements`,
WDA's own search, which returns points and never passes through `applyScale`. They worked
before this change and are untouched by it.

### Testing

Two tests in `resolve-element.test.ts`, which had no coverage of `applyScale`: one pins the
iOS conversion using the real numbers from the device above (353 of 442 across a 402-point
screen lands on 321), the other pins that Android still doubles 100 to 200.

```
npm run build      # ok
npx tsc --noEmit   # ok
npx vitest run     # 71 files / 1489 tests passed
```

Baseline on `release/v4.2.0` (`1072f43`) is 71 files / 1487 tests.

### Verified on hardware

macOS, Xcode 26.6, booted iPhone 17 Pro. `getScreenPointSize()` returns 402x874 against the
screenshot's 1206x2622, a ratio of exactly 3.00 — the factor the manual taps had to be
divided by.

Driven through the MCP server against a real app, the same call before and after:

```
before   input(tap, x:353, y:92)  ->  "Tapped at (963, 251)"   screen unchanged
after    input(tap, x:353, y:92)  ->  "Tapped at (321, 84)"    screen changed to Settings
```

321,84 is what `ui(tree)` reports for that control, so the three coordinate spaces now agree:
a coordinate read off the screenshot, a coordinate read off the tree, and the point the tap
actually reaches.
